### PR TITLE
55 - Serving self (hateoas) links for callback urls, events and funds

### DIFF
--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/eventsubscription/EventSubscriptionApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/eventsubscription/EventSubscriptionApi.java
@@ -29,8 +29,10 @@ import javax.validation.Valid;
 import java.security.Principal;
 
 @Api(value = "event-subscriptions", description = "the event subscriptions API")
-@RequestMapping(value = "/open-banking/v3.1.2/event-subscriptions")
+@RequestMapping(value = "/open-banking/v3.1.2")
 public interface EventSubscriptionApi {
+
+    String BASE_PATH = "/event-subscriptions";
 
     @ApiOperation(value = "Create an event subscription", nickname = "createEventSubscription", notes = "", response = OBEventSubscriptionResponse1.class, authorizations = {
             @Authorization(value = "TPPOAuth2Security", scopes = {
@@ -51,7 +53,7 @@ public interface EventSubscriptionApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(
+    @RequestMapping(value = BASE_PATH,
             produces = {"application/json; charset=utf-8"},
             consumes = {"application/json; charset=utf-8"},
             method = RequestMethod.POST)
@@ -94,7 +96,7 @@ public interface EventSubscriptionApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(
+    @RequestMapping(value = BASE_PATH,
             produces = {"application/json; charset=utf-8"},
             method = RequestMethod.GET)
     ResponseEntity<OBEventSubscriptionsResponse1> readEventSubscription(
@@ -130,7 +132,7 @@ public interface EventSubscriptionApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(value = "/{EventSubscriptionId}",
+    @RequestMapping(value = "/event-subscriptions/{EventSubscriptionId}",
             produces = {"application/json; charset=utf-8"},
             consumes = {"application/json; charset=utf-8"},
             method = RequestMethod.PUT)
@@ -177,7 +179,7 @@ public interface EventSubscriptionApi {
             @ApiResponse(code = 429, message = "Too Many Requests"),
             @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)})
 
-    @RequestMapping(value = "/{EventSubscriptionId}",
+    @RequestMapping(value = "/event-subscriptions/{EventSubscriptionId}",
             method = RequestMethod.DELETE)
     ResponseEntity deleteEventSubscription(
             @ApiParam(value = "EventSubscriptionId", required = true)

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_0/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_0/CallbackUrlsApiController.java
@@ -33,10 +33,10 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.util.*;
 
-import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
-import static com.forgerock.securebanking.openbanking.uk.rs.common.util.EventApiResponseUtil.packageResponse;
-import static com.forgerock.securebanking.openbanking.uk.rs.common.util.VersionPathExtractor.getVersionFromPath;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.event.FRCallbackUrlConverter.toFRCallbackUrlData;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.CallbackUrlsResponseUtil.packageResponse;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.VersionPathExtractor.getVersionFromPath;
+import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 import static org.springframework.http.HttpStatus.*;
 
 @Controller("CallbackUrlsApiV3.0")
@@ -85,7 +85,7 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
 
         return ResponseEntity
                 .status(CREATED)
-                .body(packageResponse(frCallbackUrl, getVersionFromPath(request)));
+                .body(packageResponse(frCallbackUrl, getVersionFromPath(request), this.getClass()));
     }
 
     @Override
@@ -100,10 +100,10 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
         Collection<FRCallbackUrl> callbackUrls = callbackUrlsRepository.findByTppId(tppId);
         if (callbackUrls.isEmpty()) {
             log.warn("No CallbackURL found for tpp id '{}'", tppId);
-            return ResponseEntity.ok(packageResponse(Collections.emptyList(), getVersionFromPath(request)));
+            return ResponseEntity.ok(packageResponse(Collections.emptyList(), getVersionFromPath(request), this.getClass()));
         }
         // A TPP must only create a callback-url on one version
-        return ResponseEntity.ok(packageResponse(new ArrayList<>(callbackUrls), getVersionFromPath(request)));
+        return ResponseEntity.ok(packageResponse(new ArrayList<>(callbackUrls), getVersionFromPath(request), this.getClass()));
     }
 
     @Override
@@ -127,7 +127,7 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
             if (isAccessToResourceAllowed(apiVersion, resourceVersion)) {
                 frCallbackUrl.setCallbackUrl(toFRCallbackUrlData(obCallbackUrl1));
                 callbackUrlsRepository.save(frCallbackUrl);
-                return ResponseEntity.ok(packageResponse(frCallbackUrl, apiVersion));
+                return ResponseEntity.ok(packageResponse(frCallbackUrl, apiVersion, this.getClass()));
             } else {
                 return ResponseEntity
                         .status(CONFLICT)

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApiController.java
@@ -35,7 +35,7 @@ import java.security.Principal;
 import java.util.*;
 
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.event.FRCallbackUrlConverter.toFRCallbackUrlData;
-import static com.forgerock.securebanking.openbanking.uk.rs.common.util.EventApiResponseUtil.packageResponse;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.CallbackUrlsResponseUtil.packageResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.VersionPathExtractor.getVersionFromPath;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 import static org.springframework.http.HttpStatus.*;
@@ -85,7 +85,7 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
 
         return ResponseEntity
                 .status(CREATED)
-                .body(packageResponse(frCallbackUrl, getVersionFromPath(request)));
+                .body(packageResponse(frCallbackUrl, getVersionFromPath(request), this.getClass()));
     }
 
     @Override
@@ -99,10 +99,10 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
         Collection<FRCallbackUrl> callbackUrls = callbackUrlsRepository.findByTppId(tppId);
         if (callbackUrls.isEmpty()) {
             log.warn("No CallbackURL found for tpp id '{}'", tppId);
-            return ResponseEntity.ok(packageResponse(Collections.emptyList(), getVersionFromPath(request)));
+            return ResponseEntity.ok(packageResponse(Collections.emptyList(), getVersionFromPath(request), this.getClass()));
         }
         // A TPP must only create a callback-url on one version
-        OBCallbackUrlsResponse1 responseBody = packageResponse(new ArrayList<>(callbackUrls), getVersionFromPath(request));
+        OBCallbackUrlsResponse1 responseBody = packageResponse(new ArrayList<>(callbackUrls), getVersionFromPath(request), this.getClass());
         return ResponseEntity.ok(responseBody);
     }
 
@@ -127,7 +127,7 @@ public class CallbackUrlsApiController implements CallbackUrlsApi {
                 FRCallbackUrlData callbackUrl = toFRCallbackUrlData(obCallbackUrl1);
                 frCallbackUrl.setCallbackUrl(callbackUrl);
                 callbackUrlsRepository.save(frCallbackUrl);
-                return ResponseEntity.ok(packageResponse(frCallbackUrl, apiVersion));
+                return ResponseEntity.ok(packageResponse(frCallbackUrl, apiVersion, this.getClass()));
             } else {
                 return ResponseEntity
                         .status(CONFLICT)

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/eventsubscription/EventSubscriptionApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/eventsubscription/EventSubscriptionApiController.java
@@ -37,8 +37,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.event.FREventSubscriptionConverter.toFREventSubscriptionData;
-import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.VersionPathExtractor.getVersionFromPath;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.*;
+import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 
 @Controller("EventSubscriptionApiV3.1.2")
 @Slf4j
@@ -201,9 +202,7 @@ public class EventSubscriptionApiController implements EventSubscriptionApi {
                     .data(new OBEventSubscriptionsResponse1Data()
                             .eventSubscription(eventSubsByClient))
                     .meta(new Meta())
-                    //.links(resourceLinkService.toSelfLink(discovery -> discovery.getVersion(eventResponseUtil.version).getGetCallbackUrls()));
-                    // TODO - fix this as part of #55
-                    .links(new Links());
+                    .links(createEventSubscriptionResourcesLink(this.getClass()));
         }
     }
 
@@ -216,9 +215,7 @@ public class EventSubscriptionApiController implements EventSubscriptionApi {
                         .eventTypes(obEventSubs.getEventTypes())
                         .version(obEventSubs.getVersion())
                 )
-                //.links(resourceLinkService.toSelfLink(frEventSubscription, discovery -> discovery.getVersion(eventResponseUtil.version).getGetCallbackUrls()))
-                // TODO - fix this as part of #55
-                .links(new Links())
+                .links(createEventSubscriptionSelfLink(this.getClass(), frEventSubscription.getId()))
                 .meta(new Meta());
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApiController.java
@@ -25,7 +25,6 @@ import org.joda.time.DateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import uk.org.openbanking.datamodel.account.Links;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.fund.OBFundsConfirmation1;
 import uk.org.openbanking.datamodel.fund.OBFundsConfirmationDataResponse1;
@@ -38,6 +37,7 @@ import java.util.Optional;
 
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.FRAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.fund.FRFundsConfirmationConverter.toFRFundsConfirmationData;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createFundsConfirmationSelfLink;
 
 @Controller("FundsConfirmationsApiV3.0")
 @Slf4j
@@ -120,9 +120,7 @@ public class FundsConfirmationsApiController implements FundsConfirmationsApi {
                         .reference(obFundsConfirmationData.getReference())
                         .consentId(fundsConfirmation.getFundsConfirmation().getConsentId()))
                 .meta(new Meta())
-                // TODO - fix this as part of #55
-                //.links(resourceLinkService.toSelfLink(fundsConfirmation, discovery -> discovery.getVersion(VersionPathExtractor.getVersionFromPath(request)).getCreateFundsConfirmation()));
-                .links(new Links());
+                .links(createFundsConfirmationSelfLink(this.getClass(), fundsConfirmation.getId()));
     }
 
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticpayments/DomesticPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticpayments/DomesticPaymentsApiController.java
@@ -42,7 +42,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConsentConverter.toOBDomestic1;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConverter.toFRWriteDomestic;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticScheduledConverter.toFRWriteDomesticScheduled;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticStandingOrderConverter.toFRWriteDomesticStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/file/FilePaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/file/FilePaymentsApiController.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRSubmissionStatusConverter.toOBExternalStatus1Code;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteFileConsentConverter.toOBFile1;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteFileConverter.toFRWriteFile;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createFilePaymentsLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createFilePaymentsLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalpayments/InternationalPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalpayments/InternationalPaymentsApiController.java
@@ -43,7 +43,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConsentConverter.toOBInternational1;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConverter.toFRWriteInternational;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConsentConverter.toOBInternationalScheduled1;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConverter.toFRWriteInternationalScheduled;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 
@@ -83,11 +83,6 @@ public class InternationalScheduledPaymentsApiController implements Internationa
             Principal principal
     ) throws OBErrorResponseException {
         log.debug("Received payment submission: '{}'", obWriteInternationalScheduled1);
-
-        // TODO - before we get this far, the IG will need to:
-        //      - verify the consent status
-        //      - verify the payment details match those in the payment consent
-        //      - verify security concerns (e.g. detached JWS, access token, roles, MTLS etc.)
 
         paymentSubmissionValidator.validateIdempotencyKeyAndRisk(xIdempotencyKey, obWriteInternationalScheduled1.getRisk());
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalStandingOrderConverter.toFRWriteInternationalStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 
@@ -83,11 +83,6 @@ public class InternationalStandingOrdersApiController implements InternationalSt
             Principal principal
     ) throws OBErrorResponseException {
         log.debug("Received payment submission: '{}'", obWriteInternationalStandingOrder1);
-
-        // TODO - before we get this far, the IG will need to:
-        //      - verify the consent status
-        //      - verify the payment details match those in the payment consent
-        //      - verify security concerns (e.g. detached JWS, access token, roles, MTLS etc.)
 
         paymentSubmissionValidator.validateIdempotencyKeyAndRisk(xIdempotencyKey, obWriteInternationalStandingOrder1.getRisk());
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticpayments/DomesticPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticpayments/DomesticPaymentsApiController.java
@@ -42,7 +42,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConsentConverter.toOBDomestic2;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConverter.toFRWriteDomestic;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticScheduledConverter.toFRWriteDomesticScheduled;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticStandingOrderConverter.toFRWriteDomesticStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/file/FilePaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/file/FilePaymentsApiController.java
@@ -44,7 +44,7 @@ import java.util.Optional;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRSubmissionStatusConverter.toOBExternalStatus1Code;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteFileConsentConverter.toOBFile2;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteFileConverter.toFRWriteFile;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createFilePaymentsLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createFilePaymentsLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalpayments/InternationalPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalpayments/InternationalPaymentsApiController.java
@@ -43,7 +43,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConsentConverter.toOBInternational2;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConverter.toFRWriteInternational;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConsentConverter.toOBInternationalScheduled2;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConverter.toFRWriteInternationalScheduled;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalStandingOrderConverter.toFRWriteInternationalStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticStandingOrderConverter.toFRWriteDomesticStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_1/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_1/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -46,7 +46,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalStandingOrderConverter.toFRWriteInternationalStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticpayments/DomesticPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticpayments/DomesticPaymentsApiController.java
@@ -49,7 +49,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConsentConverter.toOBWriteDomestic2DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConverter.toFRWriteDomestic;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -52,7 +52,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticScheduledConverter.toFRWriteDomesticScheduled;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -52,7 +52,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticStandingOrderConverter.toFRWriteDomesticStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/file/FilePaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/file/FilePaymentsApiController.java
@@ -49,7 +49,7 @@ import java.util.Optional;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRSubmissionStatusConverter.toOBExternalStatus1Code;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteFileConsentConverter.toOBFile2;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteFileConverter.toFRWriteFile;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createFilePaymentsLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createFilePaymentsLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalpayments/InternationalPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalpayments/InternationalPaymentsApiController.java
@@ -50,7 +50,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConsentConverter.toOBWriteInternational3DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConverter.toFRWriteInternational;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -52,7 +52,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduled3DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConverter.toFRWriteInternationalScheduled;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -52,7 +52,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalStandingOrderConverter.toFRWriteInternationalStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticpayments/DomesticPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticpayments/DomesticPaymentsApiController.java
@@ -52,7 +52,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConsentConverter.toOBWriteDomestic2DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConverter.toFRWriteDomestic;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frDomesticResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -53,7 +53,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticScheduledConverter.toFRWriteDomesticScheduled;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frDomesticResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -54,7 +54,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticStandingOrderConverter.toFRWriteDomesticStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frDomesticResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalpayments/InternationalPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalpayments/InternationalPaymentsApiController.java
@@ -53,7 +53,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConsentConverter.toOBWriteInternational3DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConverter.toFRWriteInternational;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frInternationalResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -54,7 +54,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduled3DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConverter.toFRWriteInternationalScheduled;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frInternationalResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -54,7 +54,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalStandingOrderConverter.toFRWriteInternationalStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frInternationalResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApiController.java
@@ -52,7 +52,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConsentConverter.toOBWriteDomestic2DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticConverter.toFRWriteDomestic;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frDomesticResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApiController.java
@@ -55,7 +55,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticScheduledConverter.toFRWriteDomesticScheduled;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frDomesticResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticstandingorders/DomesticStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticstandingorders/DomesticStandingOrdersApiController.java
@@ -55,7 +55,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteDomesticStandingOrderConverter.toFRWriteDomesticStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.INITIATIONPENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createDomesticStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frDomesticResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/file/FilePaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/file/FilePaymentsApiController.java
@@ -50,7 +50,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRSubmissionStatusConverter.toOBWriteFileResponse3DataStatus;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteFileConsentConverter.toOBWriteFile2DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteFileConverter.toFRWriteFile;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createFilePaymentsLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createFilePaymentsLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 import static org.springframework.http.HttpStatus.CREATED;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApiController.java
@@ -53,7 +53,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConsentConverter.toOBWriteInternational3DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalConverter.toFRWriteInternational;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frInternationalResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentsApiController.java
@@ -55,7 +55,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduled3DataInitiation;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalScheduledConverter.toFRWriteInternationalScheduled;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRScheduledPaymentDataFactory.createFRScheduledPaymentData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalScheduledPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalScheduledPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frInternationalResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalstandingorders/InternationalStandingOrdersApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalstandingorders/InternationalStandingOrdersApiController.java
@@ -55,7 +55,7 @@ import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamo
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.converter.payment.FRWriteInternationalStandingOrderConverter.toFRWriteInternationalStandingOrder;
 import static com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRSubmissionStatus.PENDING;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.FRStandingOrderDataFactory.createFRStandingOrderData;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.LinksHelper.createInternationalStandingOrderPaymentLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createInternationalStandingOrderPaymentLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRReadRefundAccountFactory.frReadRefundAccount;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frInternationalResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.PaymentApiResponseUtil.resourceConflictResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/OBApiReference.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/OBApiReference.java
@@ -30,12 +30,7 @@ import static org.springframework.http.HttpMethod.*;
  */
 public enum OBApiReference {
 
-    // TODO - remove consent related APIs
-
     /** Account and Transactions Api **/
-    CREATE_ACCOUNT_ACCESS_CONSENT(AISP, "CreateAccountAccessConsent", POST, "/aisp/account-access-consents"),
-    DELETE_ACCOUNT_ACCESS_CONSENT(AISP, "DeleteAccountAccessConsent", DELETE, "/aisp/account-access-consents/{ConsentId}"),
-    GET_ACCOUNT_ACCESS_CONSENT(AISP, "GetAccountAccessConsent", GET, "/aisp/account-access-consents/{ConsentId}"),
 
     GET_ACCOUNTS(AISP, "GetAccounts", GET, "/aisp/accounts"),
     GET_ACCOUNT(AISP, "GetAccount", GET, "/aisp/accounts/{AccountId}"),
@@ -68,9 +63,6 @@ public enum OBApiReference {
     GET_STATEMENTS(AISP, "GetStatements", GET, "/aisp/statements"),
 
     /** Funds Api **/
-    CREATE_FUNDS_CONFIRMATION_CONSENT(CBPII, "CreateFundsConfirmationConsent", POST, "/cbpii/funds-confirmation-consents"),
-    GET_FUNDS_CONFIRMATION_CONSENT(CBPII, "GetFundsConfirmationConsent", GET, "/cbpii/funds-confirmation-consents/{ConsentId}"),
-    DELETE_FUNDS_CONFIRMATION_CONSENT(CBPII, "DeleteFundsConfirmationConsent", DELETE, "/cbpii/funds-confirmation-consents/{ConsentId}"),
     CREATE_FUNDS_CONFIRMATION(CBPII, "CreateFundsConfirmation", POST, "/cbpii/funds-confirmations"),
     GET_FUNDS_CONFIRMATION(CBPII, "GetFundsConfirmation", GET, "/cbpii/funds-confirmations/{FundsConfirmationId}"),
 
@@ -89,41 +81,24 @@ public enum OBApiReference {
     EVENT_AGGREGATED_POLLING(EVENT, "EventAggregatedPolling", GET, "/events"),
 
     /** Payments Api **/
-    CREATE_DOMESTIC_PAYMENT_CONSENT(PISP, "CreateDomesticPaymentConsent", POST, "/pisp/domestic-payment-consents"),
-    GET_DOMESTIC_PAYMENT_CONSENT(PISP, "GetDomesticPaymentConsent", GET, "/pisp/domestic-payment-consents/{ConsentId}"),
     CREATE_DOMESTIC_PAYMENT(PISP, "CreateDomesticPayment", POST, "/pisp/domestic-payments"),
     GET_DOMESTIC_PAYMENT(PISP, "GetDomesticPayment", GET, "/pisp/domestic-payments/{DomesticPaymentId}"),
-    GET_DOMESTIC_PAYMENT_CONSENT_ID_FUNDS_CONFIRMATION(PISP, "GetDomesticPaymentConsentIdFundsConfirmation", GET, "/pisp/domestic-payment-consents/{ConsentId}/funds-confirmation"),
 
-    CREATE_DOMESTIC_SCHEDULED_PAYMENT_CONSENT(PISP, "CreateDomesticScheduledPaymentConsent", POST, "/pisp/domestic-scheduled-payment-consents"),
-    GET_DOMESTIC_SCHEDULED_PAYMENT_CONSENT(PISP, "GetDomesticScheduledPaymentConsent", GET, "/pisp/domestic-scheduled-payment-consents/{ConsentId}"),
     CREATE_DOMESTIC_SCHEDULED_PAYMENT(PISP, "CreateDomesticScheduledPayment", POST, "/pisp/domestic-scheduled-payment-consents"),
     GET_DOMESTIC_SCHEDULED_PAYMENT(PISP, "GetDomesticScheduledPayment", GET, "/pisp/domestic-scheduled-payments/{DomesticScheduledPaymentId}"),
 
-    CREATE_DOMESTIC_STANDING_ORDER_CONSENT(PISP, "CreateDomesticStandingOrderConsent", POST, "/pisp/domestic-standing-order-consents"),
-    GET_DOMESTIC_STANDING_ORDER_CONSENT(PISP, "GetDomesticStandingOrderConsent", GET, "/pisp/domestic-standing-order-consents/{ConsentId}"),
     CREATE_DOMESTIC_STANDING_ORDER(PISP, "CreateDomesticStandingOrder", POST, "/pisp/domestic-standing-orders"),
     GET_DOMESTIC_STANDING_ORDER(PISP, "GetDomesticStandingOrder", GET, "/pisp/domestic-standing-orders/{DomesticStandingOrderId}"),
 
-    CREATE_INTERNATIONAL_PAYMENT_CONSENT(PISP, "CreateInternationalPaymentConsent", POST, "/pisp/international-payment-consents"),
-    GET_INTERNATIONAL_PAYMENT_CONSENT(PISP, "GetInternationalPaymentConsent", GET, "/pisp/international-payment-consents/{ConsentId}"),
     CREATE_INTERNATIONAL_PAYMENT(PISP, "CreateInternationalPayment", POST, "/pisp/international-payments"),
     GET_INTERNATIONAL_PAYMENT(PISP, "GetInternationalPayment", GET, "/pisp/international-payments/{InternationalPaymentId}"),
-    GET_INTERNATIONAL_PAYMENT_CONSENT_ID_FUNDS_CONFIRMATION(PISP, "GetInternationalPaymentConsentIdFundsConfirmation", GET, "/pisp/international-payment-consents/{ConsentId}/funds-confirmation"),
 
-    CREATE_INTERNATIONAL_SCHEDULED_PAYMENT_CONSENT(PISP, "CreateInternationalScheduledPaymentConsent", POST, "/pisp/international-scheduled-payment-consents"),
-    GET_INTERNATIONAL_SCHEDULED_PAYMENT_CONSENT(PISP, "GetInternationalScheduledPaymentConsent", GET, "/pisp/international-scheduled-payment-consents/{ConsentId}"),
     CREATE_INTERNATIONAL_SCHEDULED_PAYMENT(PISP, "CreateInternationalScheduledPayment", POST, "/pisp/international-scheduled-payments"),
     GET_INTERNATIONAL_SCHEDULED_PAYMENT(PISP, "GetInternationalScheduledPayment", GET, "/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}"),
-    GET_INTERNATIONAL_SCHEDULED_PAYMENT_CONSENT_ID_FUNDS_CONFIRMATION(PISP, "GetInternationalScheduledPaymentConsentIdFundsConfirmation", GET, "/pisp/international-scheduled-payment-consents/{ConsentId}/funds-confirmation"),
 
-    CREATE_INTERNATIONAL_STANDING_ORDER_CONSENT(PISP, "CreateInternationalStandingOrderConsent", POST, "/pisp/international-standing-order-consents"),
-    GET_INTERNATIONAL_STANDING_ORDER_CONSENT(PISP, "GetInternationalStandingOrderConsent", GET, "/pisp/international-standing-order-consents/{ConsentId}"),
     CREATE_INTERNATIONAL_STANDING_ORDER(PISP, "CreateInternationalStandingOrder", POST, "/pisp/international-standing-orders"),
     GET_INTERNATIONAL_STANDING_ORDER(PISP, "GetInternationalStandingOrder", GET, "/pisp/international-standing-orders/{InternationalStandingOrderId}"),
 
-    CREATE_FILE_PAYMENT_CONSENT(PISP, "CreateFilePaymentConsent", POST, "/pisp/file-payment-consents"),
-    GET_FILE_PAYMENT_CONSENT(PISP, "GetFilePaymentConsent", GET, "/pisp/file-payment-consents/{ConsentId}"),
 
     CREATE_FILE_PAYMENT_FILE(PISP, "CreateFilePaymentFile", POST, "/pisp/file-payment-consents/{ConsentId}/file"),
     GET_FILE_PAYMENT_FILE(PISP, "GetFilePaymentFile", GET, "/pisp/file-payment-consents/{ConsentId}/file"),

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/CallbackUrlsResponseUtil.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/CallbackUrlsResponseUtil.java
@@ -19,7 +19,6 @@ import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.eve
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.event.FRCallbackUrl;
 import lombok.extern.slf4j.Slf4j;
-import uk.org.openbanking.datamodel.account.Links;
 import uk.org.openbanking.datamodel.account.Meta;
 import uk.org.openbanking.datamodel.event.OBCallbackUrlResponse1;
 import uk.org.openbanking.datamodel.event.OBCallbackUrlResponseData1;
@@ -30,14 +29,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.forgerock.securebanking.openbanking.uk.common.api.meta.OBVersion.v3_0;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createCallbackUrlsResourcesLink;
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createCallbackUrlsSelfLink;
 import static com.forgerock.securebanking.openbanking.uk.rs.validator.ResourceVersionValidator.isAccessToResourceAllowed;
 
 /**
- * Helps build responses for the Event Notification API, according to the "Release Management" rules of the OB API. For
- * example, refer to https://openbankinguk.github.io/read-write-api-site3/v3.1.3/profiles/callback-url-api-profile.html#release-management
+ * Helps build responses for the Callback API, according to the "Release Management" rules of the OB API. For example,
+ * refer to https://openbankinguk.github.io/read-write-api-site3/v3.1.3/profiles/callback-url-api-profile.html#release-management
  */
 @Slf4j
-public class EventApiResponseUtil {
+public class CallbackUrlsResponseUtil {
 
     /**
      * Provides the required {@link OBCallbackUrlsResponse1} instance, filtered according to the API version rules. Any
@@ -45,18 +46,20 @@ public class EventApiResponseUtil {
      *
      * @param apiVersion The version of the API currently being invoked.
      * @param frCallbackUrls A {@link List} {@link FRCallbackUrl} to be returned in the response.
+     * @param controllerClass The controller class that is responsible for handling the self link.
      * @return The {@link OBCallbackUrlsResponse1}, containing zero or more {@link FRCallbackUrl FRCallbackUrls}.
      */
-    public static OBCallbackUrlsResponse1 packageResponse(List<FRCallbackUrl> frCallbackUrls, OBVersion apiVersion) {
-        FRCallbackUrl frCallbackUrl = !frCallbackUrls.isEmpty() ? frCallbackUrls.get(0) : null;
+    public static OBCallbackUrlsResponse1 packageResponse(List<FRCallbackUrl> frCallbackUrls,
+                                                          OBVersion apiVersion,
+                                                          Class<?> controllerClass) {
         List<OBCallbackUrlResponseData1> filteredUrls = frCallbackUrls.stream()
                 .filter(it -> isAccessToResourceAllowed(apiVersion, OBVersion.fromString(it.getCallbackUrl().getVersion())))
-                .map(EventApiResponseUtil::toOBCallbackUrlResponseData1)
+                .map(CallbackUrlsResponseUtil::toOBCallbackUrlResponseData1)
                 .collect(Collectors.toList());
         return new OBCallbackUrlsResponse1()
                 .data(new OBCallbackUrlsResponseData1().callbackUrl(filteredUrls))
                 .meta(hasMetaSection(apiVersion) ? new Meta() : null)
-                .links(hasMetaSection(apiVersion) ? toSelfLink(frCallbackUrl, apiVersion) : null);
+                .links(hasMetaSection(apiVersion) ? createCallbackUrlsResourcesLink(controllerClass) : null);
     }
 
     /**
@@ -65,13 +68,16 @@ public class EventApiResponseUtil {
      *
      * @param apiVersion The version of the API currently being invoked.
      * @param frCallbackUrl The {@link FRCallbackUrl} containing the data for the response.
+     * @param controllerClass The controller class that is responsible for handling the self link.
      * @return the populated {@link OBCallbackUrlResponse1} response
      */
-    public static OBCallbackUrlResponse1 packageResponse(FRCallbackUrl frCallbackUrl, OBVersion apiVersion) {
+    public static OBCallbackUrlResponse1 packageResponse(FRCallbackUrl frCallbackUrl,
+                                                         OBVersion apiVersion,
+                                                         Class<?> controllerClass) {
         return new OBCallbackUrlResponse1()
                 .data(toOBCallbackUrlResponseData1(frCallbackUrl))
                 .meta(hasMetaSection(apiVersion) ? new Meta() : null)
-                .links(hasMetaSection(apiVersion) ? toSelfLink(frCallbackUrl, apiVersion) : null);
+                .links(hasMetaSection(apiVersion) ? createCallbackUrlsSelfLink(controllerClass, frCallbackUrl.getId()) : null);
     }
 
     private static OBCallbackUrlResponseData1 toOBCallbackUrlResponseData1(FRCallbackUrl frCallbackUrl) {
@@ -80,12 +86,6 @@ public class EventApiResponseUtil {
                 .callbackUrlId(frCallbackUrl.getId())
                 .url(data.getUrl())
                 .version(data.getVersion());
-    }
-
-    private static Links toSelfLink(FRCallbackUrl frCallbackUrl, OBVersion obVersion) {
-        // TODO - fix this as part of #55
-        return new Links();
-        //return resourceLinkService.toSelfLink(frCallbackUrl, discovery -> discovery.getVersion(version).getGetCallbackUrls());
     }
 
     private static boolean hasMetaSection(OBVersion apiVersion) {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/link/LinksHelper.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/link/LinksHelper.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment;
+package com.forgerock.securebanking.openbanking.uk.rs.common.util.link;
 
 import org.springframework.hateoas.Link;
 import uk.org.openbanking.datamodel.account.Links;
@@ -32,6 +32,10 @@ public class LinksHelper {
     private static final String INTERNATIONAL_PAYMENTS = "international-payments";
     private static final String INTERNATIONAL_SCHEDULED_PAYMENTS = "international-scheduled-payments";
     private static final String INTERNATIONAL_STANDING_ORDER = "international-standing-orders";
+
+    private static final String CALLBACK_URLS = "callback-urls";
+    private static final String EVENT_SUBSCRIPTIONS = "event-subscriptions";
+    private static final String FUNDS_CONFIRMATION = "funds-confirmations";
 
     /**
      * Creates an instance of the OB {@link Links} class with only the 'self' link populated for a domestic payment.
@@ -116,7 +120,63 @@ public class LinksHelper {
     }
 
     /**
-     * Uses Spring HATEOAS to create an instance of the OB {@link Links} class with only the 'self' link populated.
+     * Creates an instance of the OB {@link Links} class with only the 'self' link populated for returning callback URLs.
+     *
+     * @param controllerClass The controller class that is responsible for handling the self link.
+     * @param id The ID of the resource concerned.
+     * @return The {@link Links} instance with the populated 'self' URL.
+     */
+    public static Links createCallbackUrlsSelfLink(Class<?> controllerClass, String id) {
+        return createSelfLink(controllerClass, CALLBACK_URLS, id);
+    }
+
+    /**
+     * Creates an instance of the OB {@link Links} class with only the 'self' link populated for returning callback URLs.
+     *
+     * @param controllerClass The controller class that is responsible for handling the self link.
+     * @return The {@link Links} instance with the populated 'self' URL.
+     */
+    public static Links createCallbackUrlsResourcesLink(Class<?> controllerClass) {
+        return createResourcesLink(controllerClass, CALLBACK_URLS);
+    }
+
+    /**
+     * Creates an instance of the OB {@link Links} class with only the 'self' link populated for an event subscription.
+     *
+     * @param controllerClass The controller class that is responsible for handling the self link.
+     * @param id The ID of the resource concerned.
+     * @return The {@link Links} instance with the populated 'self' URL.
+     */
+    public static Links createEventSubscriptionSelfLink(Class<?> controllerClass, String id) {
+        return createSelfLink(controllerClass, EVENT_SUBSCRIPTIONS, id);
+    }
+
+    /**
+     * Creates an instance of the OB {@link Links} class with only the 'self' link populated for the event subscription
+     * resources.
+     *
+     * @param controllerClass The controller class that is responsible for handling the self link.
+     * @return The {@link Links} instance with the populated 'self' URL.
+     */
+    public static Links createEventSubscriptionResourcesLink(Class<?> controllerClass) {
+        return createResourcesLink(controllerClass, EVENT_SUBSCRIPTIONS);
+    }
+
+    /**
+     * Creates an instance of the OB {@link Links} class with only the 'self' link populated for a funds confirmation
+     * resource.
+     *
+     * @param controllerClass The controller class that is responsible for handling the self link.
+     * @param id The ID of the resource concerned.
+     * @return The {@link Links} instance with the populated 'self' URL.
+     */
+    public static Links createFundsConfirmationSelfLink(Class<?> controllerClass, String id) {
+        return createSelfLink(controllerClass, FUNDS_CONFIRMATION, id);
+    }
+
+    /**
+     * Uses Spring HATEOAS to create an instance of the OB {@link Links} class with the 'self' link pointing to a
+     * specific resource (e.g. /callback-urls/{id}).
      *
      * @param controllerClass The controller class that is responsible for handling the self link.
      * @param resourcePath The relative path of the resource to retrieve
@@ -125,6 +185,19 @@ public class LinksHelper {
      */
     private static Links createSelfLink(Class<?> controllerClass, String resourcePath, String id) {
         Link link = linkTo(controllerClass).slash(resourcePath).slash(id).withSelfRel();
+        return new Links().self(link.getHref());
+    }
+
+    /**
+     * Uses Spring HATEOAS to create an instance of the OB {@link Links} class with the self link pointing to a
+     * resource's base path (e.g. /callback-urls).
+     *
+     * @param controllerClass The controller class that is responsible for handling the self link.
+     * @param resourcePath The relative path of the resource to retrieve
+     * @return The {@link Links} instance with the populated 'self' URL.
+     */
+    private static Links createResourcesLink(Class<?> controllerClass, String resourcePath) {
+        Link link = linkTo(controllerClass).slash(resourcePath).withSelfRel();
         return new Links().self(link.getHref());
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/callbackurl/CallbackUrlsApiControllerTest.java
@@ -81,8 +81,7 @@ public class CallbackUrlsApiControllerTest {
         assertThat(responseData.getUrl()).isEqualTo(obCallbackUrl1.getData().getUrl());
         assertThat(responseData.getVersion()).isEqualTo(obCallbackUrl1.getData().getVersion());
         assertThat(response.getBody().getMeta()).isNotNull();
-        // TODO - enable as part of #54
-        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl()));
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(callbackIdUrl(responseData.getCallbackUrlId()));
     }
 
     @Test
@@ -105,8 +104,7 @@ public class CallbackUrlsApiControllerTest {
         assertThat(callbackUrlResponse.getUrl()).isEqualTo(obCallbackUrl1.getData().getUrl());
         assertThat(callbackUrlResponse.getVersion()).isEqualTo(obCallbackUrl1.getData().getVersion());
         assertThat(response.getBody().getMeta()).isNotNull();
-        // TODO - enable as part of #54
-        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl));
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(callbacksUrl);
     }
 
     @Test
@@ -127,6 +125,7 @@ public class CallbackUrlsApiControllerTest {
         // Then
         assertThat(response.getStatusCode()).isEqualTo(OK);
         assertThat(response.getBody().getData().getUrl()).isEqualTo(updatedCallbackUrl);
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(url);
     }
 
     @Test

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/eventsubscription/EventSubscriptionApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/event/v3_1_2/eventsubscription/EventSubscriptionApiControllerTest.java
@@ -80,8 +80,7 @@ public class EventSubscriptionApiControllerTest {
         assertThat(responseData.getVersion()).isEqualTo(eventSubscription.getData().getVersion());
         assertThat(responseData.getEventTypes()).isEqualTo(eventSubscription.getData().getEventTypes());
         assertThat(response.getBody().getMeta()).isNotNull();
-        // TODO - enable as part of #54
-        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl()));
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(eventSubscriptionsIdUrl(responseData.getEventSubscriptionId()));
     }
 
     @Test
@@ -103,8 +102,7 @@ public class EventSubscriptionApiControllerTest {
         assertThat(eventSubscriptions.get(0).getVersion()).isEqualTo(eventSubscription.getData().getVersion());
         assertThat(eventSubscriptions.get(0).getEventTypes()).isEqualTo(eventSubscription.getData().getEventTypes());
         assertThat(response.getBody().getMeta()).isNotNull();
-        // TODO - enable as part of #54
-        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl()));
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(eventSubscriptionsUrl());
     }
 
     @Test
@@ -127,8 +125,7 @@ public class EventSubscriptionApiControllerTest {
         OBEventSubscriptionResponse1Data responseData = response.getBody().getData();
         assertThat(responseData.getCallbackUrl()).isEqualTo("http://updatedcallbackurl.com");
         assertThat(response.getBody().getMeta()).isNotNull();
-        // TODO - enable as part of #54
-        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl()));
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(updateUrl);
     }
 
     @Test

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/funds/v3_0/FundsConfirmationsApiControllerTest.java
@@ -24,7 +24,6 @@ import com.forgerock.securebanking.openbanking.uk.rs.persistence.document.accoun
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.accounts.FRAccountRepository;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.accounts.balances.FRBalanceRepository;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.funds.FundsConfirmationRepository;
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +51,7 @@ import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
-/**OBFundsConfirmationResponse1
+/**
  * A SpringBoot test for the {@link FundsConfirmationsApiController}.
  */
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -112,8 +111,7 @@ public class FundsConfirmationsApiControllerTest {
         assertThat(responseData.getReference()).isEqualTo(fundsConfirmation.getData().getReference());
         assertThat(responseData.getInstructedAmount()).isEqualTo(fundsConfirmation.getData().getInstructedAmount());
         assertThat(response.getBody().getMeta()).isNotNull();
-        // TODO - enable as part of #54
-        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl()));
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(fundsConfirmationsIdUrl(responseData.getFundsConfirmationId()));
     }
 
     @Test
@@ -134,9 +132,8 @@ public class FundsConfirmationsApiControllerTest {
         assertThat(responseData.getFundsAvailable()).isTrue();
         assertThat(responseData.getReference()).isEqualTo(fundsConfirmation.getData().getReference());
         assertThat(responseData.getInstructedAmount()).isEqualTo(fundsConfirmation.getData().getInstructedAmount());
-        AssertionsForClassTypes.assertThat(response.getBody().getMeta()).isNotNull();
-        // TODO - enable as part of #54
-        //assertThat(response.getBody().getLinks().getFirst().equals(callbacksUrl()));
+        assertThat(response.getBody().getMeta()).isNotNull();
+        assertThat(response.getBody().getLinks().getSelf().equals(url));
     }
 
     private String fundsConfirmationsUrl() {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/discovery/AvailableApisTestDataFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/discovery/AvailableApisTestDataFactory.java
@@ -53,8 +53,8 @@ public class AvailableApisTestDataFactory {
 
     public static List<AvailableApiEndpoint> generatePaymentApis() {
         List<Pair<OBApiReference, String>> content = ImmutableList.of(
-                Pair.of(OBApiReference.CREATE_DOMESTIC_PAYMENT_CONSENT, "/pisp/domestic-payment-consents"),
-                Pair.of(OBApiReference.GET_DOMESTIC_PAYMENT_CONSENT, "/pisp/domestic-payment-consents/{ConsentId}")
+                Pair.of(OBApiReference.CREATE_DOMESTIC_PAYMENT, "/pisp/domestic-payment"),
+                Pair.of(OBApiReference.GET_DOMESTIC_PAYMENT, "/pisp/domestic-payment/{PaymentId}")
         );
         return generateApi(OBGroupName.PISP, content);
     }


### PR DESCRIPTION
### Self (hateoas) links for callback urls, events and funds

- Providing a consistent way to provide self links across the Read/Write API (except for the Accounts API which is paginated).
- Addressed numerous TODO comments

**Issue**: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/55