### PR TITLE
add configurable ingress

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/ingress.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
   name: {{ .Chart.Name }}
 spec:
   rules:
-  - host: {{ .Values.ingress.host }}
+  - host: {{ .Values.ingress.subdomain }}.{{ .Values.ingress.domain }}
     http:
       paths:
       - backend:
@@ -22,5 +22,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - {{ .Values.ingress.host }}
+    - "{{ .Values.ingress.tls.subdomain }}.{{ .Values.ingress.domain }}"
     secretName: {{ .Values.ingress.tls.secretName }}

--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -28,9 +28,11 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 100k
 
-  host: localhost
+  domain: localhost
+  subdomain: rs
   tls:
     secretName: selfSignedCert
+    subdomain: "*"
   
 service:
   apiVersion: v1


### PR DESCRIPTION
Give the ingress a configurable domain and subdomain. default tls to wildcard.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs/issues/40