### PR TITLE
fix mongo and sslconfig

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             timeoutSeconds: 5
           env:
           - name: SPRING_DATA_MONGODB_HOST
-            value: "mongodb"
+            value: {{ .Values.mongodb.host }}
           - name: SERVER_PORT
             value: {{ .Values.deployment.server.port | quote }}
           - name: SPRING_CLOUD_CONFIG_URI

--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -19,6 +19,9 @@ deployment:
 
   resources: {}
 
+mongodb:
+  host: mongo-dev
+
 ingress:
   apiVersion: extensions/v1beta1
   class: nginx
@@ -31,7 +34,7 @@ ingress:
   domain: localhost
   subdomain: rs
   tls:
-    secretName: selfSignedCert
+    secretName: sslcert
     subdomain: "*"
   
 service:


### PR DESCRIPTION
Allow for a configurable mongo host. default to suffix the namespace `mongo-dev`.

Change the default sslcert for consistency across all securebanking applications `sslcert`