### PR TITLE
add mongodb namespace config

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -51,7 +51,11 @@ spec:
             timeoutSeconds: 5
           env:
           - name: SPRING_DATA_MONGODB_HOST
-            value: {{ .Values.mongodb.host }}
+            {{- if .Values.mongodb.argoControlled }}
+            value: mongodb-{{ .Values.mongodb.namespace }}
+            {{- else }}]
+            value: mongodb
+            {{- end }}
           - name: SERVER_PORT
             value: {{ .Values.deployment.server.port | quote }}
           - name: SPRING_CLOUD_CONFIG_URI

--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -20,7 +20,8 @@ deployment:
   resources: {}
 
 mongodb:
-  host: mongo-dev
+  argoControlled: true
+  namespace: dev
 
 ingress:
   apiVersion: extensions/v1beta1


### PR DESCRIPTION
Deploying the mongodb chart into a different namespace will suffix the service with that namespace for argo deployments.
apply logic to add the suffix for a given namespace if the deployment is argo controlled.