### PR TITLE
remove https nginx annotation

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -27,7 +27,6 @@ ingress:
   apiVersion: extensions/v1beta1
   class: nginx
   additionalAnnotations:
-    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/client-body-buffer-size: 1m
     nginx.ingress.kubernetes.io/proxy-body-size: 150m
     nginx.ingress.kubernetes.io/proxy-buffer-size: 100k


### PR DESCRIPTION
Remove the backend protocol from the rs ingress. it does not need to be https, we use this ingress only for ease of development. The ingress itself would not be in a production environment as all traffic is routed through IG.