### PR TITLE
make latest tag on merge only

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker repo=${{ secrets.RELEASE_REPO }}
+          make docker tag=latest
 
       - name: helm version
         id: helm

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,9 +64,7 @@ jobs:
       
       - name: Build Docker Image
         run: |
-          make docker tag=latest
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/$SERVICE_NAME:latest eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/$SERVICE_NAME:${{ steps.tag.outputs.pr_number }}
-          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/$SERVICE_NAME:${{ steps.tag.outputs.pr_number }}
+          make docker tag=${{ steps.tag.outputs.pr_number }}
 
       - uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
Change pr to only use the `pr-<prNumber>` tag and move the latest tag to the merge action.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs/issues/54