### PR TITLE
76: Derive base URL from X-Forwarded headers

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -62,7 +62,5 @@ spec:
             value: "http://securebanking-spring-config-server:8080"
           - name: SPRING_PROFILES_ACTIVE
             value: "docker"
-          - name: RS_BASEURL
-            value: http://rs:8080
           resources:
             {{- toYaml .Values.deployment.resources | nindent 12 }}

--- a/securebanking-openbanking-uk-rs-simulator-sample/docker/config/securebanking-openbanking-uk-rs-docker.yml
+++ b/securebanking-openbanking-uk-rs-simulator-sample/docker/config/securebanking-openbanking-uk-rs-docker.yml
@@ -24,7 +24,6 @@ spring:
 
 # RS config
 rs:
-  baseUrl: http://localhost:8080
   discovery:
     financialId: 0015800001041REAAY
 

--- a/securebanking-openbanking-uk-rs-simulator-sample/src/test/resources/application-test.yml
+++ b/securebanking-openbanking-uk-rs-simulator-sample/src/test/resources/application-test.yml
@@ -9,7 +9,6 @@ spring:
       port: 0
 
 rs:
-  baseUrl: http://localhost:8080
   discovery:
     financialId: 0015800001041REAAY
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpointsResolver.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpointsResolver.java
@@ -16,13 +16,13 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 
 import com.forgerock.securebanking.openbanking.uk.rs.common.OBApiReference;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,14 +46,10 @@ public class AvailableApiEndpointsResolver {
 
     private final Map<RequestMappingInfo, HandlerMethod> handlerMethods;
 
-    private final String baseUrl;
+    private List<AvailableApiEndpoint> availableApis = new ArrayList<>();
 
-    private List<AvailableApiEndpoint> availableApis = null;
-
-    public AvailableApiEndpointsResolver(RequestMappingHandlerMapping requestHandlerMapping,
-                                         @Value("${rs.baseUrl}") String baseUrl) {
+    public AvailableApiEndpointsResolver(RequestMappingHandlerMapping requestHandlerMapping) {
         this.handlerMethods = requestHandlerMapping.getHandlerMethods();
-        this.baseUrl = baseUrl;
     }
 
     /**
@@ -66,12 +62,6 @@ public class AvailableApiEndpointsResolver {
      * @return the {@link List} of {@link AvailableApiEndpoint} instances.
      */
     public List<AvailableApiEndpoint> getAvailableApiEndpoints() {
-        if (availableApis != null) {
-            return availableApis;
-        }
-
-        availableApis = new ArrayList<>();
-
         for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : handlerMethods.entrySet()) {
             RequestMappingInfo requestMapping = entry.getKey();
             HandlerMethod method = entry.getValue();
@@ -80,6 +70,7 @@ public class AvailableApiEndpointsResolver {
 
             if (apiReference != null) {
                 String version = getVersion(requestMapping);
+                String baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
                 String url = baseUrl + requestMapping.getPatternsCondition().getPatterns().iterator().next();
 
                 AvailableApiEndpoint availableApi = AvailableApiEndpoint.builder()

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/WebMvcConfig.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/WebMvcConfig.java
@@ -16,7 +16,9 @@
 package com.forgerock.securebanking.openbanking.uk.rs.configuration;
 
 import com.forgerock.securebanking.openbanking.uk.rs.web.DisabledEndpointInterceptor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -27,6 +29,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     public WebMvcConfig(DisabledEndpointInterceptor disabledEndpointInterceptor) {
         this.disabledEndpointInterceptor = disabledEndpointInterceptor;
+    }
+
+    @Bean
+    ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
     }
 
     @Override

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpointsResolverTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/AvailableApiEndpointsResolverTest.java
@@ -18,9 +18,13 @@ package com.forgerock.securebanking.openbanking.uk.rs.api.discovery;
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.OBGroupName;
 import com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_1_5.domesticpayments.DomesticPaymentsApiController;
 import com.forgerock.securebanking.openbanking.uk.rs.common.OBApiReference;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
@@ -39,16 +43,22 @@ import static org.mockito.Mockito.mock;
  */
 public class AvailableApiEndpointsResolverTest {
 
-    private static final String BASE_URL = "http://rs";
+    private static final String BASE_URL = "http://localhost";
     private static final String VERSION = "v3.1.5";
     private static final String CREATE_PAYMENT_URI = "/open-banking/" + VERSION + "/pisp/domestic-payments";
     private static final String GET_PAYMENT_URI = "/open-banking/" + VERSION + "/pisp/domestic-payments/{DomesticPaymentId}";
+
+    @BeforeEach
+    void setup() {
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockRequest));
+    }
 
     @Test
     public void shouldGetAvailableApiEndpoints() {
         // Given
         RequestMappingHandlerMapping requestHandlerMapping = requestHandlerMapping();
-        AvailableApiEndpointsResolver endpointsResolver = new AvailableApiEndpointsResolver(requestHandlerMapping, BASE_URL);
+        AvailableApiEndpointsResolver endpointsResolver = new AvailableApiEndpointsResolver(requestHandlerMapping);
 
         // When
         List<AvailableApiEndpoint> availableApiEndpoints = endpointsResolver.getAvailableApiEndpoints();

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryApiServiceTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/DiscoveryApiServiceTest.java
@@ -51,10 +51,9 @@ public class DiscoveryApiServiceTest {
         when(availableApisResolver.getAvailableApiEndpoints()).thenReturn(AvailableApisTestDataFactory.getAvailableApiEndpoints());
 
         // When
-        discoveryApiService.init();
+        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
 
         // Then
-        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
         assertThat(discoveryApis).isNotNull();
         assertThat(containsAllVersions(discoveryApis.get(OBGroupName.AISP))).isTrue();
         assertThat(containsAllVersions(discoveryApis.get(OBGroupName.PISP))).isTrue();
@@ -71,10 +70,9 @@ public class DiscoveryApiServiceTest {
         when(availableApisResolver.getAvailableApiEndpoints()).thenReturn(AvailableApisTestDataFactory.getAvailableApiEndpoints());
 
         // When
-        discoveryApiService.init();
+        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
 
         // Then
-        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
         assertThat(discoveryApis).isNotNull();
         assertThat(containsAllVersionsExcept(discoveryApis.get(OBGroupName.AISP), 1)).isTrue();
         assertThat(containsAllVersionsExcept(discoveryApis.get(OBGroupName.PISP), 1)).isTrue();
@@ -91,10 +89,9 @@ public class DiscoveryApiServiceTest {
         when(availableApisResolver.getAvailableApiEndpoints()).thenReturn(AvailableApisTestDataFactory.getAvailableApiEndpoints());
 
         // When
-        discoveryApiService.init();
+        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
 
         // Then
-        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
         Map<String, OBDiscoveryAPI> accountApis = discoveryApis.get(OBGroupName.AISP);
         assertThat(containsAllVersions(accountApis)).isTrue();
         Map<String, String> links = ((GenericOBDiscoveryAPILinks) accountApis.get(TEST_VERSION).getLinks()).getLinks();
@@ -114,10 +111,9 @@ public class DiscoveryApiServiceTest {
         when(availableApisResolver.getAvailableApiEndpoints()).thenReturn(AvailableApisTestDataFactory.getAvailableApiEndpoints());
 
         // When
-        discoveryApiService.init();
+        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
 
         // Then
-        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
         Map<String, OBDiscoveryAPI> accountApis = discoveryApis.get(OBGroupName.AISP);
         String version = "v3.1.2";
         Map<String, String> links = ((GenericOBDiscoveryAPILinks) accountApis.get(version).getLinks()).getLinks();
@@ -143,10 +139,9 @@ public class DiscoveryApiServiceTest {
         when(availableApisResolver.getAvailableApiEndpoints()).thenReturn(emptyList());
 
         // When
-        discoveryApiService.init();
+        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
 
         // Then
-        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
         assertThat(discoveryApis).isEmpty();
     }
 
@@ -159,10 +154,9 @@ public class DiscoveryApiServiceTest {
         when(availableApisResolver.getAvailableApiEndpoints()).thenReturn(AvailableApisTestDataFactory.getAvailableApiEndpoints());
 
         // When
-        discoveryApiService.init();
+        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
 
         // Then
-        Map<OBGroupName, Map<String, OBDiscoveryAPI>> discoveryApis = discoveryApiService.getDiscoveryApis();
         assertThat(discoveryApis).isEmpty();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/link/LinksHelperTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/link/LinksHelperTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.common.util.link;
+
+import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.DomesticPaymentSubmissionRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomestic1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticResponse1;
+
+import java.util.UUID;
+
+import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static uk.org.openbanking.testsupport.payment.OBRisk1TestDataFactory.aValidOBRisk1;
+import static uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.aValidOBDomestic1;
+
+/**
+ * Spring Boot Test for {@link LinksHelper}.
+ *
+ * <p>
+ * Due to the complexity of mocking an HTTP request and all of the Spring Boot context, this class tests the
+ * {@link LinksHelper} indirectly via one of the Payment API controllers. This is probably the most reliable way to
+ * ensure the "self" links are returned correctly.
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+public class LinksHelperTest {
+    private static final String BASE_URL = "http://localhost:";
+    private static final String DOMESTIC_PAYMENTS_URI = "/open-banking/v3.0/pisp/domestic-payments";
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private DomesticPaymentSubmissionRepository domesticPaymentRepository;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @AfterEach
+    void removeData() {
+        domesticPaymentRepository.deleteAll();
+    }
+
+    @Test
+    public void shouldGetSelfLinkWithDefaultDomain() {
+        // Given
+        OBWriteDomestic1 payment = aValidOBWriteDomestic1();
+        HttpHeaders headers = requiredPaymentHttpHeaders();
+        HttpEntity<OBWriteDomestic1> request = new HttpEntity<>(payment, headers);
+        ResponseEntity<OBWriteDomesticResponse1> persistedPayment = restTemplate.postForEntity(paymentsUrl(), request, OBWriteDomesticResponse1.class);
+        String url = paymentIdUrl(persistedPayment.getBody().getData().getDomesticPaymentId());
+
+        // When
+        ResponseEntity<OBWriteDomesticResponse1> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), OBWriteDomesticResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        OBWriteDataDomesticResponse1 responseData = response.getBody().getData();
+        String expectedUrl = "http://localhost:" + port + "/open-banking/v3.0/pisp/domestic-payments/" + responseData.getDomesticPaymentId();
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(expectedUrl);
+    }
+
+    @Test
+    public void shouldGetSelfLinkWithProvidedDomain() {
+        // Given
+        OBWriteDomestic1 payment = aValidOBWriteDomestic1();
+        HttpHeaders headers = requiredPaymentHttpHeaders();
+        headers.add("X-Forwarded-Host", "forgerock.com");
+        headers.add("X-Forwarded-Proto", "https");
+        HttpEntity<OBWriteDomestic1> request = new HttpEntity<>(payment, headers);
+        ResponseEntity<OBWriteDomesticResponse1> persistedPayment = restTemplate.postForEntity(paymentsUrl(), request, OBWriteDomesticResponse1.class);
+        String url = paymentIdUrl(persistedPayment.getBody().getData().getDomesticPaymentId());
+
+        // When
+        ResponseEntity<OBWriteDomesticResponse1> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), OBWriteDomesticResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        OBWriteDataDomesticResponse1 responseData = response.getBody().getData();
+        String expectedUrl = "https://forgerock.com/open-banking/v3.0/pisp/domestic-payments/" + responseData.getDomesticPaymentId();
+        assertThat(response.getBody().getLinks().getSelf()).isEqualTo(expectedUrl);
+    }
+
+    private String paymentsUrl() {
+        return BASE_URL + port + DOMESTIC_PAYMENTS_URI;
+    }
+
+    private String paymentIdUrl(String id) {
+        return paymentsUrl() + "/" + id;
+    }
+
+    private OBWriteDomestic1 aValidOBWriteDomestic1() {
+        return new OBWriteDomestic1()
+                .data(aValidOBWriteDataDomestic1())
+                .risk(aValidOBRisk1());
+    }
+
+    private OBWriteDataDomestic1 aValidOBWriteDataDomestic1() {
+        return new OBWriteDataDomestic1()
+                .consentId(UUID.randomUUID().toString())
+                .initiation(aValidOBDomestic1());
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/resources/application-test.yml
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/resources/application-test.yml
@@ -16,7 +16,6 @@ springfox:
         path: /api-docs
 
 rs:
-  baseUrl: http://localhost:8080
   discovery:
     financialId: 0015800001041REAAY
 


### PR DESCRIPTION
### Derive base URL from X-Forwarded headers

Ensure URLs returned from the RS simulator are derived from the X-Forwarded headers. Specifically URLs from:

* The Discovery endpoint (`/open-banking/discovery`)
* The Swagger documentation endpoint (`/api-docs`)
* Self links to resources from the Payments, Events or Fund Confirmation URLs (excluding the Accounts API which uses the `x-ob-url` header).

**N.B.** If X-Forwarded headers are not provided then the RS simulator defaults to `http://localhost:8080`.

**Issue**: https://github.com/SecureBankingAccessToolkit/SecureBankingAcceleratorToolkit/issues/76