### PR TITLE
add Prometheus support

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/service.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/service.yaml
@@ -2,10 +2,13 @@ apiVersion: {{ .Values.service.apiVersion }}
 kind: Service
 metadata:
   name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.service.type }}
   ports:
-  - port: 8080
+  - name: {{ .Chart.Name }}
+    port: 8080
     targetPort: {{ .Values.deployment.server.port }}
     protocol: TCP
   selector:

--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -39,3 +39,4 @@ ingress:
   
 service:
   apiVersion: v1
+  type: ClusterIP

--- a/securebanking-openbanking-uk-rs-simulator-sample/pom.xml
+++ b/securebanking-openbanking-uk-rs-simulator-sample/pom.xml
@@ -105,6 +105,10 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/securebanking-openbanking-uk-rs-simulator-sample/src/main/resources/application.yml
+++ b/securebanking-openbanking-uk-rs-simulator-sample/src/main/resources/application.yml
@@ -13,6 +13,12 @@ spring:
   profiles:
     active: NOT_SET
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+        
 #Swagger
 springfox:
   documentation:


### PR DESCRIPTION
Add `app` label to the Service Manifest for matching with the prometheus ServiceMonitor manifest.

Add the micrometer dependency to the sample service and add prometeus to the exposed actuator endpoints.

issue: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs/issues/57