### PR TITLE
add mongodb host and tagDelimiter

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/deployment.yaml
@@ -24,9 +24,9 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.deployment.imageOverride.enabled }}
-          image: "{{ .Values.deployment.imageOverride.repo }}:{{ .Values.deployment.imageOverride.tag }}"
+          image: "{{ .Values.deployment.imageOverride.repo }}{{ .Values.deployment.imageOverride.tagDelimiter }}{{ .Values.deployment.imageOverride.tag }}"
           {{- else }}
-          image: "eu.gcr.io/sbat-gcr-release/securebanking/${ .Chart.Name }:{{ .Chart.AppVersion }}"
+          image: "eu.gcr.io/sbat-gcr-release/securebanking/{{ .Chart.Name }}:{{ .Chart.AppVersion }}"
           {{- end }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
           ports:
@@ -51,11 +51,7 @@ spec:
             timeoutSeconds: 5
           env:
           - name: SPRING_DATA_MONGODB_HOST
-            {{- if .Values.mongodb.argoControlled }}
-            value: mongodb-{{ .Values.mongodb.namespace }}
-            {{- else }}]
-            value: mongodb
-            {{- end }}
+            value: {{ .Values.mongodb.host }}
           - name: SERVER_PORT
             value: {{ .Values.deployment.server.port | quote }}
           - name: SPRING_CLOUD_CONFIG_URI

--- a/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/values.yaml
@@ -13,6 +13,7 @@ deployment:
     enabled: true
     repo: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-openbanking-uk-rs
     tag: latest
+    tagDelimiter: ":"
 
   server:
     port: 8080
@@ -20,8 +21,7 @@ deployment:
   resources: {}
 
 mongodb:
-  argoControlled: true
-  namespace: dev
+  host: mongodb
 
 ingress:
   apiVersion: extensions/v1beta1


### PR DESCRIPTION
Add a tagDelimiter to allow selecting an image by digest rather than tag name.
This is required for the `dev` environment which is updated via the `latest`digest.

remove the argo controlled mongodb and simply add host.
issue: https://github.com/SecureBankingAccessToolkit/sbat-cd/issues/21