### PR TITLE
add docker tags for different action steps

### DIFF
--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -42,25 +42,16 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          make docker repo=${{ secrets.RELEASE_REPO }}
           make docker tag=latest
-
-      - name: helm version
-        id: helm
-        run: |
-          HELM_VERSION=$(make version)
-          echo ::set-output name=version::"$HELM_VERSION"
-
-      - name: package helm
-        run: |
-          make helm version=${{ steps.helm.outputs.version }}
-
-      - name: Publish Release Chart 
-        id: upload
-        uses: google-github-actions/upload-cloud-storage@main
+      
+      - name: 'run functional tests'
+        uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          path: ${{ env.SERVICE_NAME }}-${{ steps.helm.outputs.version }}.tgz
-          destination: ${{ secrets.HELM_RELEASE_BUCKET }}/${{ env.SERVICE_NAME }}
+          args: '-v SERVICE_NAME=rs'
+        env:
+          PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+        id: run-pipeline
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/merge-master.yml
+++ b/.github/workflows/merge-master.yml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          make docker tag=latest
+          make docker tag=${{ github.sha }}
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:{{ github.sha }} eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
+          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME }}:latest
       
       - name: 'run functional tests'
         uses: codefresh-io/codefresh-pipeline-runner@master

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,7 @@ on:
 env:
   HELM_DIRECTORY: _infra/helm/
   SERVICE_NAME: securebanking-openbanking-uk-rs
+  PR_NUMBER: pr-${{ github.event.number }}
 
 jobs:
   build:
@@ -36,14 +37,6 @@ jobs:
       - name: template helm
         run: |
           helm template $HELM_DIRECTORY/$SERVICE_NAME
-    
-      - name: package helm
-        run: |
-          make helm version=latest
-      
-      - name: Publish PR Chart
-        run: |
-          gsutil cp $SERVICE_NAME-*.tgz gs://${{ secrets.HELM_DEV_BUCKET }}/$SERVICE_NAME/
 
       - name: Check Copyright
         run: mvn license:check
@@ -54,17 +47,12 @@ jobs:
       
       - run: |
           gcloud auth configure-docker
-
-      - name: pr docker tag
-        id: tag
-        run: |
-          PR=$(echo "$GITHUB_REF" | awk -F / '{print $3}')
-          echo "$PR"
-          echo ::set-output name=pr_number::pr-"$PR"
       
       - name: Build Docker Image
         run: |
-          make docker tag=${{ steps.tag.outputs.pr_number }}
+          make docker tag=${{ env.PR_NUMBER }}
+          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:{{ github.sha }} eu.gcr.io/${{ secrets.DEV_REPO }}:latest
+          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
 
       - uses: codecov/codecov-action@v1
         with:
@@ -73,7 +61,7 @@ jobs:
       - name: 'run functional tests'
         uses: codefresh-io/codefresh-pipeline-runner@master
         with:
-          args: '-v TAG=${{ steps.tag.outputs.pr_number }} -v SERVICE_NAME=rs -v ENVIRONMENT=${{ github.actor }} -v BRANCH=${{ github.head_ref }}'
+          args: '-v TAG=${{ env.PR_NUMBER }} -v SERVICE_NAME=rs -v ENVIRONMENT=${{ github.actor }} -v BRANCH=${{ github.head_ref }}'
         env:
           PIPELINE_NAME: 'ForgeCloud/sbat-infra/service-build'
           CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,8 +51,6 @@ jobs:
       - name: Build Docker Image
         run: |
           make docker tag=${{ env.PR_NUMBER }}
-          docker tag eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:{{ github.sha }} eu.gcr.io/${{ secrets.DEV_REPO }}:latest
-          docker push eu.gcr.io/${{ secrets.DEV_REPO }}/securebanking/${{ env.SERVICE_NAME}}:latest
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,20 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.FR_ARTIFACTORY_USER }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.FR_ARTIFACTORY_TOKEN }}
+      
+      - name: helm version
+        id: helm
+        run: |
+          HELM_VERSION=$(make version)
+          echo ::set-output name=version::"$HELM_VERSION"
+
+      - name: package helm
+        run: |
+          make helm version=${{ steps.helm.outputs.version }}
+
+      - name: Publish Release Chart 
+        id: upload
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: ${{ env.SERVICE_NAME }}-${{ steps.helm.outputs.version }}.tgz
+          destination: ${{ secrets.HELM_RELEASE_BUCKET }}/${{ env.SERVICE_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,3 +52,7 @@ jobs:
         with:
           path: ${{ env.SERVICE_NAME }}-${{ steps.helm.outputs.version }}.tgz
           destination: ${{ secrets.HELM_RELEASE_BUCKET }}/${{ env.SERVICE_NAME }}
+      
+      - name: Release Docker Image
+        run: |
+          make docker tag=${{ github.event.release.tag_name }} gcr-repo=${{ secrets.RELEASE_REPO }}


### PR DESCRIPTION
Add github sha to docker image on merge to master.
add github tag to docker image and push to release repo when a release is made

remove all release repo references from merge/pr actions.

Publishing a helm chart is not required at the merge or pr phase.

issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/89