### PR TITLE
297: Modify the funds confirmation route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .mongo/
 .factorypath
 target/
+.idea/
+*.iml

--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApi.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApi.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
 
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
@@ -51,12 +52,24 @@ public interface PaymentFundsConfirmationApi {
     @RequestMapping(value = "/payment-funds-confirmation/{accountId}",
             produces = {"application/json; charset=utf-8", "application/jose+jwe"},
             method = RequestMethod.GET)
-    ResponseEntity<FRFundsConfirmationResponse> getPaymentFundsConfirmation(
+    ResponseEntity<OBWriteFundsConfirmationResponse1> getPaymentFundsConfirmation(
             @ApiParam(value = "AccountId", required = true)
             @PathVariable("accountId") String accountId,
 
             @ApiParam(value = "Amount", required = true)
             @RequestParam("amount") String amount,
+
+            @ApiParam(value = "Version", required = true)
+            @RequestParam("version") String version,
+
+            @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
+            @RequestHeader(value = "Authorization", required = true) String authorization,
+
+            @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
+            @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false) String xFapiAuthDate,
 
             @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
             @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApiController.java
@@ -15,16 +15,21 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment;
 
-import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRFundsConfirmationResponse;
 import com.forgerock.securebanking.openbanking.uk.rs.service.balance.FundsAvailabilityService;
 import lombok.extern.slf4j.Slf4j;
 import org.joda.time.DateTime;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import uk.org.openbanking.datamodel.common.Meta;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1Data;
+import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1DataFundsAvailableResult;
 
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
+
+import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticPaymentsConsentFundsConfirmationLink;
 
 @Controller
 @Slf4j
@@ -37,9 +42,13 @@ public class PaymentFundsConfirmationApiController implements PaymentFundsConfir
     }
 
     @Override
-    public ResponseEntity<FRFundsConfirmationResponse> getPaymentFundsConfirmation(
+    public ResponseEntity<OBWriteFundsConfirmationResponse1> getPaymentFundsConfirmation(
             String accountId,
             String amount,
+            String version,
+            String authorization,
+            String xFapiFinancialId,
+            String xFapiAuthDate,
             String xFapiCustomerIpAddress,
             String xFapiInteractionId,
             String xCustomerUserAgent,
@@ -51,10 +60,19 @@ public class PaymentFundsConfirmationApiController implements PaymentFundsConfir
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(FRFundsConfirmationResponse.builder()
-                        .isFundsAvailable(areFundsAvailable)
-                        .fundsAvailableDateTime(DateTime.now())
-                        .build()
+                .body(
+                        new OBWriteFundsConfirmationResponse1()
+                                .data(
+                                        new OBWriteFundsConfirmationResponse1Data()
+                                                .fundsAvailableResult(
+                                                        new OBWriteFundsConfirmationResponse1DataFundsAvailableResult()
+                                                                .fundsAvailable(areFundsAvailable)
+                                                                .fundsAvailableDateTime(DateTime.now())
+                                                )
+                                                .supplementaryData(null)
+                                )
+                                .links(createDomesticPaymentsConsentFundsConfirmationLink(this.getClass(), version, accountId))
+                                .meta(new Meta())
                 );
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/link/LinksHelper.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/util/link/LinksHelper.java
@@ -24,7 +24,11 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
  * Helper class for creating the OB {@link Links} class in an HTTP response.
  */
 public class LinksHelper {
+    private static final String PISP = "pisp";
+    private static final String RS = "rs";
 
+    private static final String OPEN_BANKING = "open-banking";
+    private static final String DOMESTIC_PAYMENTS_CONSENT = "domestic-payments-consent";
     private static final String DOMESTIC_PAYMENTS = "domestic-payments";
     private static final String DOMESTIC_SCHEDULED_PAYMENTS = "domestic-scheduled-payments";
     private static final String DOMESTIC_STANDING_ORDER = "domestic-standing-orders";
@@ -32,11 +36,23 @@ public class LinksHelper {
     private static final String INTERNATIONAL_PAYMENTS = "international-payments";
     private static final String INTERNATIONAL_SCHEDULED_PAYMENTS = "international-scheduled-payments";
     private static final String INTERNATIONAL_STANDING_ORDER = "international-standing-orders";
-
     private static final String CALLBACK_URLS = "callback-urls";
     private static final String EVENT_SUBSCRIPTIONS = "event-subscriptions";
-    private static final String FUNDS_CONFIRMATION = "funds-confirmations";
+    private static final String FUNDS_CONFIRMATION = "funds-confirmation";
+    private static final String FUNDS_CONFIRMATIONS = "funds-confirmations";
     private static final String DOMESTIC_VRP_PAYMENTS = "domestic-vrps";
+
+    /**
+     * Creates an instance of the OB {@link Links} class with only the 'self' link populated for a domestic payments consent funds confirmation.
+     *
+     * @param id The version of the resource concerned.
+     * @param id The ID of the resource concerned.
+     * @return The {@link Links} instance with the populated 'self' URL.
+     */
+    public static Links createDomesticPaymentsConsentFundsConfirmationLink(Class<?> controllerClass, String version, String id) {
+        Link link = linkTo(controllerClass).slash(RS).slash(OPEN_BANKING).slash(version).slash(PISP).slash(DOMESTIC_PAYMENTS_CONSENT).slash(id).slash(FUNDS_CONFIRMATION).withSelfRel();
+        return new Links().self(link.getHref());
+    }
 
     /**
      * Creates an instance of the OB {@link Links} class with only the 'self' link populated for a domestic payment.
@@ -183,7 +199,7 @@ public class LinksHelper {
      * @return The {@link Links} instance with the populated 'self' URL.
      */
     public static Links createFundsConfirmationSelfLink(Class<?> controllerClass, String id) {
-        return createSelfLink(controllerClass, FUNDS_CONFIRMATION, id);
+        return createSelfLink(controllerClass, FUNDS_CONFIRMATIONS, id);
     }
 
     /**

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
@@ -93,6 +93,21 @@ public class HttpHeadersTestDataFactory {
     }
 
     /**
+     * @return an instance of {@link HttpHeaders} with the minimal set of required headers for the Payment Funds Confirmation API.
+     */
+    public static HttpHeaders requiredPaymentFundsConfirmationHttpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth("dummyAuthToken");
+        headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
+        headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
+        headers.add("x-idempotency-key", UUID.randomUUID().toString());
+        headers.add("x-ob-account-id", UUID.randomUUID().toString());
+        return headers;
+    }
+
+    /**
      * Provides an instance of {@link HttpHeaders} with the minimal set of required headers for the Events API.
      *
      * @param resourceUrl The URL to retrieve the resource in question.


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/297

### Implementation
- The existing API /backoffice/payment-funds-confirmation was changed to use as a response body the class OBWriteFundsConfirmationResponse1.
- The unit tests were updated.