### PR TITLE
Fix ingress 404 error

### DIFF
--- a/_infra/helm/securebanking-openbanking-uk-rs/templates/ingress.yaml
+++ b/_infra/helm/securebanking-openbanking-uk-rs/templates/ingress.yaml
@@ -22,7 +22,7 @@ spec:
             port:
               number: 8080
         path: /
-        pathType: Exact
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ .Values.ingress.tls.subdomain }}.{{ .Values.ingress.domain }}"


### PR DESCRIPTION
Change pathType to prefix to fix nginx 404 not found error for https://obdemo.dev.forgerock.financial/ig(/%7C$)(.*)