### PR TITLE
428: Backoffice API to calculate payment consent response elements

### DIFF
--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElements.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElements.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment;
+
+import com.forgerock.securebanking.openbanking.uk.error.OBErrorResponseException;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.swagger.SwaggerApiTags;
+import io.swagger.annotations.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+
+@Api(tags = {SwaggerApiTags.BACKOFFICE})
+@RequestMapping({"/backoffice/payment-consent"})
+public interface CalculateResponseElements {
+
+    @ApiOperation(value = "Calculate payment consent response elements", response = String.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Response elements successfully calculated", response = String.class),
+            @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
+            @ApiResponse(code = 403, message = "Validation failed", response = OBErrorResponse1.class)
+    })
+    @RequestMapping(value = "/calculate-elements",
+            produces = {"application/json; charset=utf-8"},
+            method = RequestMethod.POST)
+    ResponseEntity calculateElements(
+            @ApiParam(value = "Create an Account Access Consents", required = true)
+            @Valid
+            @RequestBody String body,
+
+            @ApiParam(value = "Consent type", required = true)
+            @RequestParam(value = "intent") String intent,
+
+            @ApiParam(value = "Api version", required = true)
+            @RequestParam(value = "version") String version,
+            // TODO delete this header when the validations are implemented (issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/429)
+            @ApiParam(value = "Temporary Header for tests purposes, values 'true'/'false' to simulate a validation failure, default 'false'")
+            @RequestHeader(value = "x-validation-test-failure", defaultValue = "false", required = false) String xValidationTestFailure,
+
+            @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
+            @RequestHeader(value = "x-fapi-financial-id") String xFapiFinancialId,
+
+            @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
+            @RequestHeader(value = "x-fapi-auth-date", required = false) String xFapiAuthDate,
+
+            @ApiParam(value = "The PSU's IP address if the PSU is currently logged in with the TPP.")
+            @RequestHeader(value = "x-fapi-customer-ip-address", required = false) String xFapiCustomerIpAddress,
+
+            @ApiParam(value = "An RFC4122 UID used as a correlation id.")
+            @RequestHeader(value = "x-fapi-interaction-id", required = false) String xFapiInteractionId,
+
+            HttpServletRequest request
+    ) throws OBErrorResponseException;
+}

--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApi.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/PaymentFundsConfirmationApi.java
@@ -22,6 +22,7 @@ package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment;
 
 import com.forgerock.securebanking.common.openbanking.uk.forgerock.datamodel.payment.FRFundsConfirmationResponse;
 import com.forgerock.securebanking.openbanking.uk.error.OBErrorResponseException;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.swagger.SwaggerApiTags;
 import io.swagger.annotations.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,7 +32,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteFundsConfirmationResponse1;
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 
-@Api(value = "backoffice-payment-funds", description = "the Payment Funds Confirmation API")
+@Api(tags = {SwaggerApiTags.BACKOFFICE})
 @RequestMapping("/backoffice")
 public interface PaymentFundsConfirmationApi {
 
@@ -63,10 +64,10 @@ public interface PaymentFundsConfirmationApi {
             @RequestParam("version") String version,
 
             @ApiParam(value = "An Authorisation Token as per https://tools.ietf.org/html/rfc6750", required = true)
-            @RequestHeader(value = "Authorization", required = true) String authorization,
+            @RequestHeader(value = "Authorization") String authorization,
 
             @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
-            @RequestHeader(value = "x-fapi-financial-id", required = true) String xFapiFinancialId,
+            @RequestHeader(value = "x-fapi-financial-id") String xFapiFinancialId,
 
             @ApiParam(value = "The time when the PSU last logged in with the TPP.  All dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below:  Sun, 10 Sep 2017 19:43:31 UTC")
             @RequestHeader(value = "x-fapi-auth-date", required = false) String xFapiAuthDate,

--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/swagger/SwaggerApiTags.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/swagger/SwaggerApiTags.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.swagger;
+
+public class SwaggerApiTags {
+    public static final String BACKOFFICE = "Backoffice";
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/pom.xml
+++ b/securebanking-openbanking-uk-rs-simulator-server/pom.xml
@@ -95,7 +95,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-hateoas</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- swagger -->
         <dependency>
             <groupId>io.springfox</groupId>
@@ -150,6 +154,10 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
         </dependency>
     </dependencies>
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsController.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.share.IntentType;
+import com.forgerock.securebanking.openbanking.uk.error.OBErrorResponseException;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorResponseCategory;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.calculation.PaymentConsentResponseCalculation;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.calculation.PaymentConsentResponseCalculationFactory;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation.PaymentConsentValidation;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation.PaymentConsentValidationFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
+
+
+@Controller
+@Slf4j
+public class CalculateResponseElementsController implements CalculateResponseElements {
+    public static final String VALIDATION_TEST_FAILURE_HEADER = "x-validation-test-failure";
+    public static final String API_VERSION_DESCRIPTION = "Api version";
+    public static final String INTENT_TYPE_DESCRIPTION = "Intent type";
+    private ObjectMapper mapper;
+
+    public CalculateResponseElementsController(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public ResponseEntity calculateElements(
+            String body,
+            String intent,
+            String version,
+            String xValidationTestFailure,
+            String xFapiFinancialId,
+            String xFapiAuthDate,
+            String xFapiCustomerIpAddress,
+            String xFapiInteractionId,
+            HttpServletRequest request) throws OBErrorResponseException {
+        try {
+            OBVersion apiVersion = OBVersion.fromString(version);
+            isNull(apiVersion, API_VERSION_DESCRIPTION);
+            IntentType intentType = IntentType.identify(intent);
+            isNull(intentType, INTENT_TYPE_DESCRIPTION);
+
+            log.info("{}, Calculate elements for intent {} version {}", xFapiFinancialId, intentType, apiVersion.getCanonicalName());
+            log.debug("{}, Consent request\n {}", xFapiFinancialId, body);
+
+            PaymentConsentValidation validation = PaymentConsentValidationFactory.getValidationInstance(intent);
+            Object consentRequest = mapper.readValue(body, validation.getRequestClass(apiVersion));
+
+            if (validation.validate(mapper.readValue(body, consentRequest.getClass())) && !Boolean.parseBoolean(xValidationTestFailure)) {
+                log.debug("{}, Validation passed for intent {} version {}", xFapiFinancialId, intentType, apiVersion.getCanonicalName());
+
+                PaymentConsentResponseCalculation calculation = PaymentConsentResponseCalculationFactory.getCalculationInstance(intent);
+                Object consentResponseObject = mapper.readValue(body, calculation.getResponseClass(apiVersion));
+                Object consentEntityResponse = calculation.calculate(consentRequest, consentResponseObject);
+
+                log.debug("{}, Calculation done for intent {} version {}", xFapiFinancialId, intentType, apiVersion.getCanonicalName());
+                log.debug("{}, Sending the response {}", xFapiFinancialId, mapper.writeValueAsString(consentEntityResponse));
+
+                return ResponseEntity.ok(consentEntityResponse);
+            } else {
+                log.error("{}, Validation failed for intent {} version {}", xFapiFinancialId, intentType, apiVersion.getCanonicalName());
+                throw badRequestResponseException(String.format("[%s] validation failed", intentType));
+            }
+        } catch (UnsupportedOperationException | JsonProcessingException e) {
+            String message = String.format("%s", e.getMessage());
+            log.error(message);
+            throw badRequestResponseException(message);
+        }
+    }
+
+    private void isNull(Object object, String objectName) throws OBErrorResponseException {
+        if (Objects.isNull(object)) {
+            String message = String.format("It has not been possible to determine the value of '%s'", objectName);
+            log.error(message);
+            throw badRequestResponseException(message);
+        }
+    }
+
+    private OBErrorResponseException badRequestResponseException(String message) {
+        return new OBErrorResponseException(
+                HttpStatus.BAD_REQUEST,
+                OBRIErrorResponseCategory.REQUEST_INVALID,
+                OBRIErrorType.DATA_INVALID_REQUEST
+                        .toOBError1(message)
+        );
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/DomesticPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/DomesticPaymentConsentResponseCalculation.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.calculation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import lombok.extern.slf4j.Slf4j;
+import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
+import uk.org.openbanking.datamodel.payment.*;
+
+/**
+ * Validation class for Domestic Payment consent response
+ * <ul>
+ *     <li>
+ *         Consent request {@link OBWriteDomesticConsentResponse3} from v3.1.2 to 3.1.3
+ *     </li>
+ *     <li>
+ *         Consent request {@link OBWriteDomesticConsentResponse4} for v3.1.4
+ *     </li>
+ *     <li>
+ *         Consent response {@link OBWriteDomesticConsentResponse5} from 3.1.5  to 3.1.10
+ *     </li>
+ * </ul>
+ */
+@SuppressWarnings("unchecked")
+@Slf4j
+public class DomesticPaymentConsentResponseCalculation extends PaymentConsentResponseCalculation {
+    @Override
+    public Class getResponseClass(OBVersion version) {
+        log.debug("{} is the version to calculate response elements", version.getCanonicalName());
+        if (version.isBeforeVersion(OBVersion.v3_1_4)) {
+            return OBWriteDomesticConsentResponse3.class;
+        } else if (version.equals(OBVersion.v3_1_4)) {
+            return OBWriteDomesticConsentResponse4.class;
+        }
+        return OBWriteDomesticConsentResponse5.class;
+    }
+
+    @Override
+    public <T, R> R calculate(T consentRequest, R consentResponse) {
+        if (consentResponse instanceof OBWriteDomesticConsentResponse3) {
+            log.debug("OBWriteDomesticConsentResponse3 instance");
+            ((OBWriteDomesticConsentResponse3) consentResponse)
+                    .getData()
+                    .addChargesItem(
+                            new OBWriteDomesticConsentResponse3DataCharges()
+                                    .chargeBearer(OBChargeBearerType1Code.BORNEBYDEBTOR)
+                                    .amount(getDefaultAmount())
+                    );
+
+        } else if (consentResponse instanceof OBWriteDomesticConsentResponse4) {
+            log.debug("OBWriteDomesticConsentResponse4 instance");
+            ((OBWriteDomesticConsentResponse4) consentResponse)
+                    .getData()
+                    .addChargesItem(
+                            new OBWriteDomesticConsentResponse4DataCharges()
+                                    .chargeBearer(OBChargeBearerType1Code.BORNEBYDEBTOR)
+                                    .amount(getDefaultAmount())
+                    );
+        } else {
+            log.debug("OBWriteDomesticConsentResponse5 instance");
+            ((OBWriteDomesticConsentResponse5) consentResponse)
+                    .getData()
+                    .addChargesItem(
+                            new OBWriteDomesticConsentResponse5DataCharges().
+                                    chargeBearer(OBChargeBearerType1Code.BORNEBYDEBTOR)
+                                    .amount(getDefaultAmount())
+                    );
+        }
+        return consentResponse;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.calculation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
+
+public abstract class PaymentConsentResponseCalculation {
+
+    protected static final String DEFAULT_CHARGE_AMOUNT = "1.5";
+    protected static final String DEFAULT_CHARGE_CURRENCY = "GBP";
+
+    /**
+     *
+     * @param version {@link OBVersion} is the api version to identify the response object to be built
+     * @return the request consent class by version
+     */
+    public abstract Class getResponseClass(OBVersion version);
+
+    /**
+     *
+     * @param consentRequest the consent request object
+     * @param consentResponse the consent response object
+     * @return true if the validation passed, false otherwise
+     * @param <T> dealing generic type
+     * @param <R> dealing generic type
+     */
+    public abstract <T, R> R calculate(T consentRequest, R consentResponse);
+
+    /**
+     * Get defaults amount of charges
+     * @return {@link OBActiveOrHistoricCurrencyAndAmount}
+     */
+    protected OBActiveOrHistoricCurrencyAndAmount getDefaultAmount() {
+        return new OBActiveOrHistoricCurrencyAndAmount().amount(DEFAULT_CHARGE_AMOUNT).currency(DEFAULT_CHARGE_CURRENCY);
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
@@ -30,11 +30,12 @@ public abstract class PaymentConsentResponseCalculation {
      */
     public abstract Class getResponseClass(OBVersion version);
 
+
     /**
      *
-     * @param consentRequest the consent request object
-     * @param consentResponse the consent response object
-     * @return true if the validation passed, false otherwise
+     * @param consentRequest consent request object
+     * @param consentResponse consent response object
+     * @return the consent response object with calculated elements
      * @param <T> dealing generic type
      * @param <R> dealing generic type
      */

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculationFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculationFactory.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.calculation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.share.IntentType;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation.PaymentConsentValidation;
+
+public class PaymentConsentResponseCalculationFactory {
+    /**
+     * Get the calculation instance by consent type
+     * @param consentId
+     * @return a {@link PaymentConsentValidation} implementation instance
+     */
+    public static PaymentConsentResponseCalculation getCalculationInstance(String consentId) throws UnsupportedOperationException {
+        IntentType intentType = IntentType.identify(consentId);
+        switch (intentType) {
+            case PAYMENT_DOMESTIC_CONSENT -> {
+                return new DomesticPaymentConsentResponseCalculation();
+            }
+            case PAYMENT_DOMESTIC_SCHEDULED_CONSENT -> {
+                return null;
+//                return new DomesticScheduledPaymentConsentResponseCalculation();
+            }
+            case PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT -> {
+                return null;
+//                return new DomesticStandingOrdersConsentResponseCalculation();
+            }
+            case PAYMENT_INTERNATIONAL_CONSENT -> {
+                return null;
+//                return new InternationalPaymentConsentResponseCalculation();
+            }
+            case PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT -> {
+                return null;
+//                return new InternationalScheduledPaymentConsentResponseCalculation();
+            }
+            case PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT -> {
+                return null;
+//                return new InternationalStandingOrdersConsentResponseCalculation();
+            }
+            case PAYMENT_FILE_CONSENT -> {
+                return null;
+//                return new FilePaymentConsentResponseCalculation();
+            }
+            default -> {
+                String message = String.format("Invalid type for intent ID: '%s'", consentId);
+                throw new UnsupportedOperationException(message);
+            }
+        }
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticPaymentConsentValidation.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent4;
+
+/**
+ * Validation class for Domestic Payment consent request
+ * <ul>
+ *     <li>
+ *         Consent request {@link OBWriteDomesticConsent3} from v3.1.2 to 3.1.3
+ *     </li>
+ *     <li>
+ *         Consent request {@link OBWriteDomesticConsent4} from v3.1.4 to 3.1.10
+ *     </li>
+ * </ul>
+ */
+public class DomesticPaymentConsentValidation extends PaymentConsentValidation {
+    @Override
+    public Class getRequestClass(OBVersion version) {
+        if (version.isBeforeVersion(OBVersion.v3_1_4)) {
+            return OBWriteDomesticConsent3.class;
+        }
+        return OBWriteDomesticConsent4.class;
+    }
+
+    @Override
+    public <T> boolean validate(T consent) {
+        if (consent instanceof OBWriteDomesticConsent3) {
+            // TODO validate OBWriteDomesticConsent3
+            return true;
+        }
+        // TODO validate OBWriteDomesticConsent4
+        return true;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticScheduledPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticScheduledPaymentConsentValidation.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
+
+/**
+ * Validation class for Domestic Payment consent request
+ * <li>
+ *     Domestic Scheduled Payment
+ *     <ul>
+ *         <li>From 3.1.2 to 3.1.3 {@link OBWriteDomesticScheduledConsent3}</li>
+ *         <li>From 3.1.4 to 3.1.10 {@link OBWriteDomesticScheduledConsent4}</li>
+ *     </ul>
+ * </li>
+ */
+public class DomesticScheduledPaymentConsentValidation extends PaymentConsentValidation {
+    @Override
+    public Class getRequestClass(OBVersion version) {
+        if (version.isBeforeVersion(OBVersion.v3_1_4)) {
+            return OBWriteDomesticScheduledConsent3.class;
+        }
+        return OBWriteDomesticScheduledConsent4.class;
+    }
+
+    @Override
+    public <T> boolean validate(T consent) {
+        if (consent instanceof OBWriteDomesticScheduledConsent3) {
+            // TODO validate OBWriteDomesticScheduledConsent3
+            return true;
+        }
+        // TODO validate OBWriteDomesticScheduledConsent4
+        return true;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticStandingOrdersConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticStandingOrdersConsentValidation.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
+
+/**
+ * Validation class for Domestic Payment consent request
+ * <li>
+ *     Domestic Standing order
+ *     <ul>
+ *         <li>For 3.1.2 {@link OBWriteDomesticStandingOrderConsent4}</li>
+ *         <li>From 3.1.3 to 3.1.10 {@link OBWriteDomesticStandingOrderConsent5}</li>
+ *     </ul>
+ * </li>
+ */
+public class DomesticStandingOrdersConsentValidation extends PaymentConsentValidation {
+    @Override
+    public Class getRequestClass(OBVersion version) {
+        if (version.isBeforeVersion(OBVersion.v3_1_3)) {
+            return OBWriteDomesticStandingOrderConsent4.class;
+        }
+        return OBWriteDomesticStandingOrderConsent5.class;
+    }
+
+    @Override
+    public <T> boolean validate(T consent) {
+        if (consent instanceof OBWriteDomesticStandingOrderConsent4) {
+            // TODO validate OBWriteDomesticStandingOrderConsent4
+            return true;
+        }
+        // TODO validate OBWriteDomesticStandingOrderConsent5
+        return true;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentConsentValidation.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+
+/**
+ * Validation class for Domestic Payment consent request
+ * <li>
+ *     File Payment
+ *     <ul>
+ *         <li>From 3.1.2 to 3.1.10 {@link OBWriteFileConsent3}</li>
+ *     </ul>
+ * </li>
+ */
+public class FilePaymentConsentValidation extends PaymentConsentValidation {
+    @Override
+    public Class getRequestClass(OBVersion version) {
+        return OBWriteFileConsent3.class;
+    }
+
+    @Override
+    public <T> boolean validate(T consent) {
+        // TODO validate OBWriteFileConsent3
+        return true;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalPaymentConsentValidation.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
+
+/**
+ * Validation class for Domestic Payment consent request
+ * <li>
+ *     International Payment
+ *     <ul>
+ *         <li>For 3.1.2 {@link OBWriteInternationalConsent3}</li>
+ *         <li>For 3.1.3 {@link OBWriteInternationalConsent4}</li>
+ *         <li>From 3.1.4 to 3.1.10 {@link OBWriteInternationalConsent5}</li>
+ *     </ul>
+ * </li>
+ */
+public class InternationalPaymentConsentValidation extends PaymentConsentValidation {
+    @Override
+    public Class getRequestClass(OBVersion version) {
+        if (version.equals(OBVersion.v3_1_2) || version.isBeforeVersion(OBVersion.v3_1_2)) {
+            return OBWriteInternationalConsent3.class;
+        } else if (version.equals(OBVersion.v3_1_3)) {
+            return OBWriteInternationalConsent4.class;
+        }
+        return OBWriteInternationalConsent5.class;
+    }
+
+    @Override
+    public <T> boolean validate(T consent) {
+        if (consent instanceof OBWriteInternationalConsent3) {
+            // TODO validate OBWriteInternationalConsent3
+            return true;
+        } else if (consent instanceof OBWriteInternationalConsent4) {
+            // TODO validate OBWriteInternationalConsent4
+            return true;
+        }
+        // TODO validate OBWriteInternationalConsent5
+        return true;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalScheduledPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalScheduledPaymentConsentValidation.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
+
+/**
+ * Validation class for Domestic Payment consent request
+ * <li>
+ *     International Scheduled Payment
+ *     <ul>
+ *         <li>For 3.1.2 {@link OBWriteInternationalScheduledConsent3}</li>
+ *         <li>For 3.1.3 {@link OBWriteInternationalScheduledConsent4}</li>
+ *         <li>From 3.1.4 to 3.1.10 {@link OBWriteInternationalScheduledConsent5}</li>
+ *     </ul>
+ * </li>
+ *
+ */
+public class InternationalScheduledPaymentConsentValidation extends PaymentConsentValidation {
+    @Override
+    public Class getRequestClass(OBVersion version) {
+        if (version.equals(OBVersion.v3_1_2) || version.isBeforeVersion(OBVersion.v3_1_2)) {
+            return OBWriteInternationalScheduledConsent3.class;
+        } else if (version.equals(OBVersion.v3_1_3)) {
+            return OBWriteInternationalScheduledConsent4.class;
+        }
+        return OBWriteInternationalScheduledConsent5.class;
+    }
+
+    @Override
+    public <T> boolean validate(T consent) {
+        if (consent instanceof OBWriteInternationalScheduledConsent3) {
+            // TODO validate OBWriteInternationalScheduledConsent3
+            return true;
+        } else if (consent instanceof OBWriteInternationalScheduledConsent4) {
+            // TODO validate OBWriteInternationalScheduledConsent4
+        }
+        // TODO validate OBWriteInternationalScheduledConsent5
+        return true;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalStandingOrdersConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalStandingOrdersConsentValidation.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
+
+/**
+ * Validation class for Domestic Payment consent request
+ * <li>
+ *     International Standing Order
+ *     <ul>
+ *         <li>For 3.1.2 {@link OBWriteInternationalStandingOrderConsent4}</li>
+ *         <li>For 3.1.3 {@link OBWriteInternationalStandingOrderConsent5}</li>
+ *         <li>From 3.1.4 to 3.1.10 {@link OBWriteInternationalStandingOrderConsent6}</li>
+ *     </ul>
+ * </li>
+ *
+ */
+public class InternationalStandingOrdersConsentValidation extends PaymentConsentValidation {
+    @Override
+    public Class getRequestClass(OBVersion version) {
+        if (version.equals(OBVersion.v3_1_2) || version.isBeforeVersion(OBVersion.v3_1_2)) {
+            return OBWriteInternationalStandingOrderConsent4.class;
+        } else if (version.equals(OBVersion.v3_1_3)) {
+            return OBWriteInternationalStandingOrderConsent5.class;
+        }
+        return OBWriteInternationalStandingOrderConsent6.class;
+    }
+
+    @Override
+    public <T> boolean validate(T consent) {
+        if (consent instanceof OBWriteInternationalStandingOrderConsent4) {
+            // TODO validate OBWriteInternationalStandingOrderConsent4
+            return true;
+        } else if (consent instanceof OBWriteInternationalStandingOrderConsent5) {
+            // TODO validate OBWriteInternationalStandingOrderConsent5
+        }
+        // TODO validate OBWriteInternationalStandingOrderConsent6
+        return true;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidation.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+
+public abstract class PaymentConsentValidation {
+    /**
+     *
+     * @param version {@link OBVersion} is the api version to identify the request object to be validated
+     * @return the request consent class by version
+     */
+    public abstract Class getRequestClass(OBVersion version);
+
+    /**
+     *
+     * @param consent the consent request object
+     * @return true if the validation passed, false otherwise
+     * @param <T> dealing generic type
+     */
+    public abstract <T> boolean validate(T consent);
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidationFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidationFactory.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.share.IntentType;
+
+/**
+ * Factory to get the proper consent request validation instance
+ */
+public class PaymentConsentValidationFactory {
+
+    /**
+     * Get the validation instance by consent type
+     * @param consentId
+     * @return a {@link PaymentConsentValidation} implementation instance
+     */
+    public static PaymentConsentValidation getValidationInstance(String consentId) throws UnsupportedOperationException {
+        IntentType intentType = IntentType.identify(consentId);
+        switch (intentType) {
+            case PAYMENT_DOMESTIC_CONSENT -> {
+                return new DomesticPaymentConsentValidation();
+            }
+            case PAYMENT_DOMESTIC_SCHEDULED_CONSENT -> {
+                return new DomesticScheduledPaymentConsentValidation();
+            }
+            case PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT -> {
+                return new DomesticStandingOrdersConsentValidation();
+            }
+            case PAYMENT_INTERNATIONAL_CONSENT -> {
+                return new InternationalPaymentConsentValidation();
+            }
+            case PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT -> {
+                return new InternationalScheduledPaymentConsentValidation();
+            }
+            case PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT -> {
+                return new InternationalStandingOrdersConsentValidation();
+            }
+            case PAYMENT_FILE_CONSENT -> {
+                return new FilePaymentConsentValidation();
+            }
+            default -> {
+                String message = String.format("Invalid type for intent ID: '%s'", consentId);
+                throw new UnsupportedOperationException(message);
+            }
+        }
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/RsApplicationConfiguration.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/RsApplicationConfiguration.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.configuration;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.TimeZone;
+
+@Configuration
+public class RsApplicationConfiguration {
+
+    @Bean
+    public RestTemplate restTemplate(@Qualifier("mappingJacksonHttpMessageConverter") MappingJackson2HttpMessageConverter converter) {
+        RestTemplate restTemplate = new RestTemplate();
+        customiseRestTemplate(converter, restTemplate);
+        return restTemplate;
+    }
+
+    private void customiseRestTemplate(@Qualifier("mappingJacksonHttpMessageConverter") MappingJackson2HttpMessageConverter converter, RestTemplate restTemplate) {
+        List<HttpMessageConverter<?>> messageConverters = restTemplate.getMessageConverters();
+        messageConverters.removeIf(c -> c instanceof MappingJackson2HttpMessageConverter);
+        messageConverters.add(converter);
+//        restTemplate.setErrorHandler(new ClientResponseErrorHandler());
+        // support for http PATCH calls
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory(httpClient);
+        restTemplate.setRequestFactory(requestFactory);
+    }
+
+    @Bean
+    public MappingJackson2HttpMessageConverter mappingJacksonHttpMessageConverter(@Qualifier("objectMapperBuilderCustomizer") Jackson2ObjectMapperBuilderCustomizer objectMapperBuilderCustomizer) {
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        Jackson2ObjectMapperBuilder objectMapperBuilder = new Jackson2ObjectMapperBuilder();
+        objectMapperBuilderCustomizer.customize(objectMapperBuilder);
+        converter.setObjectMapper(objectMapperBuilder.build());
+        return converter;
+    }
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer objectMapperBuilderCustomizer() {
+        return (jacksonObjectMapperBuilder) -> {
+            jacksonObjectMapperBuilder.timeZone(TimeZone.getDefault());
+            jacksonObjectMapperBuilder.serializationInclusion(JsonInclude.Include.NON_NULL);
+            jacksonObjectMapperBuilder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            jacksonObjectMapperBuilder.featuresToEnable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL);
+            jacksonObjectMapperBuilder.modules(new JodaModule());
+            jacksonObjectMapperBuilder.dateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ"));
+        };
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/exceptions/GlobalExceptionHandler.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/exceptions/GlobalExceptionHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.forgerock.securebanking.openbanking.uk.rs.common;
+package com.forgerock.securebanking.openbanking.uk.rs.exceptions;
 
 import com.forgerock.securebanking.openbanking.uk.error.OBErrorException;
 import com.forgerock.securebanking.openbanking.uk.error.OBErrorResponseException;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsControllerTest.java
@@ -1,0 +1,199 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import com.forgerock.securebanking.openbanking.uk.common.api.meta.share.IntentType;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorResponseCategory;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.util.UriComponentsBuilder;
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.error.OBErrorResponse1;
+import uk.org.openbanking.datamodel.payment.*;
+
+import java.net.URI;
+
+import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.*;
+import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredBackofficeHttpHeaders;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent3;
+import static uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent4;
+
+/**
+ * Unit test for {@link CalculateResponseElementsController}
+ */
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("test")
+public class CalculateResponseElementsControllerTest {
+
+    private static final HttpHeaders HTTP_HEADERS = requiredBackofficeHttpHeaders();
+    private static final String BASE_URL = "http://localhost:";
+
+    private static final String REST_CONTEXT = "/backoffice/payment-consent/calculate-elements";
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    /*
+    Domestic payments v3.1.2
+     */
+    @Test
+    public void shouldCalculateResponseElements4PDC_v3_1_2() throws JsonProcessingException {
+        String consentId = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+        OBWriteDomesticConsent3 consentRequest = aValidOBWriteDomesticConsent3();
+
+        // When
+        ResponseEntity<OBWriteDomesticConsentResponse3> response = restTemplate.exchange(
+                getUri(consentId, OBVersion.v3_1_2.getCanonicalName()),
+                HttpMethod.POST,
+                new HttpEntity<>(mapper.writeValueAsString(consentRequest), HTTP_HEADERS),
+                OBWriteDomesticConsentResponse3.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(response.getBody().getData().getCharges()).isNotEmpty();
+    }
+
+    /*
+    Domestic payments v3.1.4
+     */
+    @Test
+    public void shouldCalculateResponseElements4PDC_v3_1_4() throws JsonProcessingException {
+        String intent = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+        OBWriteDomesticConsent4 consentRequest = aValidOBWriteDomesticConsent4();
+
+        // When
+        ResponseEntity<OBWriteDomesticConsentResponse4> response = restTemplate.exchange(
+                getUri(intent, OBVersion.v3_1_4.getCanonicalName()),
+                HttpMethod.POST,
+                new HttpEntity<>(mapper.writeValueAsString(consentRequest), HTTP_HEADERS),
+                OBWriteDomesticConsentResponse4.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(response.getBody().getData().getCharges()).isNotEmpty();
+    }
+
+    /*
+    Domestic payments v3.1.8
+     */
+    @Test
+    public void shouldCalculateResponseElements4PDC_v3_1_8() throws JsonProcessingException {
+        String intent = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+        OBWriteDomesticConsent4 consentRequest = aValidOBWriteDomesticConsent4();
+
+        // When
+        ResponseEntity<OBWriteDomesticConsentResponse5> response = restTemplate.exchange(
+                getUri(intent, OBVersion.v3_1_8.getCanonicalName()),
+                HttpMethod.POST,
+                new HttpEntity<>(mapper.writeValueAsString(consentRequest), HTTP_HEADERS),
+                OBWriteDomesticConsentResponse5.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(response.getBody().getData().getCharges()).isNotEmpty();
+    }
+
+    @Test
+    public void cannotDetermineTheVersion() throws JsonProcessingException {
+        String intent = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+        OBWriteDomesticConsent4 consentRequest = aValidOBWriteDomesticConsent4();
+
+        // When
+        ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(
+                getUri(intent, "v99.00.334"),
+                HttpMethod.POST,
+                new HttpEntity<>(mapper.writeValueAsString(consentRequest), HTTP_HEADERS),
+                OBErrorResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
+        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
+        OBError1 error = response.getBody().getErrors().get(0);
+        assertThat(error.getErrorCode()).isEqualTo(OBRIErrorType.DATA_INVALID_REQUEST.getCode().getValue());
+        assertThat(error.getMessage()).contains(String.format("It has not been possible to determine the value of '%s'", API_VERSION_DESCRIPTION));
+    }
+
+    @Test
+    public void cannotDetermineTheIntentType() throws JsonProcessingException {
+        OBWriteDomesticConsent4 consentRequest = aValidOBWriteDomesticConsent4();
+
+        // When
+        ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(
+                getUri("WRONG_INTENT", OBVersion.v3_1_8.getCanonicalName()),
+                HttpMethod.POST,
+                new HttpEntity<>(mapper.writeValueAsString(consentRequest), HTTP_HEADERS),
+                OBErrorResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
+        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
+        OBError1 error = response.getBody().getErrors().get(0);
+        assertThat(error.getErrorCode()).isEqualTo(OBRIErrorType.DATA_INVALID_REQUEST.getCode().getValue());
+        assertThat(error.getMessage()).contains(String.format("It has not been possible to determine the value of '%s'", INTENT_TYPE_DESCRIPTION));
+    }
+
+    @Test
+    public void cannotValidateTheConsent() throws JsonProcessingException {
+        String intent = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+        OBWriteDomesticConsent4 consentRequest = aValidOBWriteDomesticConsent4();
+        HttpHeaders headers = requiredBackofficeHttpHeaders();
+        headers.add(VALIDATION_TEST_FAILURE_HEADER, "true");
+
+        // When
+        ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(
+                getUri(intent, OBVersion.v3_1_8.getCanonicalName()),
+                HttpMethod.POST,
+                new HttpEntity<>(mapper.writeValueAsString(consentRequest), headers),
+                OBErrorResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
+        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
+        OBError1 error = response.getBody().getErrors().get(0);
+        assertThat(error.getErrorCode()).isEqualTo(OBRIErrorType.DATA_INVALID_REQUEST.getCode().getValue());
+        assertThat(error.getMessage()).contains(String.format("[%s] validation failed", IntentType.identify(intent).toString()));
+    }
+
+    private URI getUri(String intent, String version) {
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl(BASE_URL + port + REST_CONTEXT);
+        builder.queryParam("intent", intent);
+        builder.queryParam("version", version);
+        return builder.build().encode().toUri();
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/TestConfiguration.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/TestConfiguration.java
@@ -15,10 +15,15 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.configuration;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 
 @Configuration
@@ -31,6 +36,13 @@ public class TestConfiguration {
      */
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer jacksonObjectMapperCustomization() {
-        return jacksonObjectMapperBuilder -> jacksonObjectMapperBuilder.timeZone(TimeZone.getDefault());
+        return (jacksonObjectMapperBuilder) -> {
+            jacksonObjectMapperBuilder.timeZone(TimeZone.getDefault());
+            jacksonObjectMapperBuilder.serializationInclusion(JsonInclude.Include.NON_NULL);
+            jacksonObjectMapperBuilder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+            jacksonObjectMapperBuilder.featuresToEnable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL);
+            jacksonObjectMapperBuilder.modules(new JodaModule());
+            jacksonObjectMapperBuilder.dateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ"));
+        };
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/testsupport/api/HttpHeadersTestDataFactory.java
@@ -60,7 +60,7 @@ public class HttpHeadersTestDataFactory {
      * Provides an instance of {@link HttpHeaders} with the minimal set of required headers for the Accounts API.
      *
      * @param resourceUrl The URL to retrieve the resource in question.
-     * @param acceptHeaderValue The value to set 'Accept' header.
+     * @param acceptHeader The value to set 'Accept' header.
      *
      * @return the {@link HttpHeaders} instance.
      */
@@ -151,6 +151,18 @@ public class HttpHeadersTestDataFactory {
         headers.add("x-idempotency-key", UUID.randomUUID().toString());
         headers.add("x-jws-signature", "dummyJwsSignature");
         headers.add("x-ob-account-id", UUID.randomUUID().toString());
+        return headers;
+    }
+
+    /**
+     * @return an instance of {@link HttpHeaders} with the minimal set of required headers for backoffice payments API.
+     */
+    public static HttpHeaders requiredBackofficeHttpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add("x-fapi-financial-id", UUID.randomUUID().toString());
+        headers.add("x-fapi-interaction-id", UUID.randomUUID().toString());
         return headers;
     }
 }


### PR DESCRIPTION
- Wrote Unit tests for the new controller with base tests for domestic payment consent requests
- Created the REST API
- Created the pattern for validation
- Created the pattern for calculation
- Added RS Configuration to configure the rest template and jackson mapper
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/428