### PR TITLE
432: Handling error events for validations

### DIFF
--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElements.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElements.java
@@ -48,9 +48,6 @@ public interface CalculateResponseElements {
 
             @ApiParam(value = "Api version", required = true)
             @RequestParam(value = "version") String version,
-            // TODO delete this header when the validations are implemented (issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/429)
-            @ApiParam(value = "Temporary Header for tests purposes, values 'true'/'false' to simulate a validation failure, default 'false'")
-            @RequestHeader(value = "x-validation-test-failure", defaultValue = "false", required = false) String xValidationTestFailure,
 
             @ApiParam(value = "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB.", required = true)
             @RequestHeader(value = "x-fapi-financial-id") String xFapiFinancialId,

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/DomesticPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/DomesticPaymentConsentResponseCalculation.java
@@ -18,16 +18,19 @@ package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.cal
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
 import lombok.extern.slf4j.Slf4j;
 import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
+import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.*;
+
+import java.util.List;
 
 /**
  * Validation class for Domestic Payment consent response
  * <ul>
  *     <li>
- *         Consent request {@link OBWriteDomesticConsentResponse3} from v3.1.2 to 3.1.3
+ *         Consent response {@link OBWriteDomesticConsentResponse3} from v3.1.2 to 3.1.3
  *     </li>
  *     <li>
- *         Consent request {@link OBWriteDomesticConsentResponse4} for v3.1.4
+ *         Consent response {@link OBWriteDomesticConsentResponse4} for v3.1.4
  *     </li>
  *     <li>
  *         Consent response {@link OBWriteDomesticConsentResponse5} from 3.1.5  to 3.1.10
@@ -50,6 +53,10 @@ public class DomesticPaymentConsentResponseCalculation extends PaymentConsentRes
 
     @Override
     public <T, R> R calculate(T consentRequest, R consentResponse) {
+        errors.clear();
+        // TODO logic to add errors when validate the request
+//      errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1("Error message reason"));
+//      return false;
         if (consentResponse instanceof OBWriteDomesticConsentResponse3) {
             log.debug("OBWriteDomesticConsentResponse3 instance");
             ((OBWriteDomesticConsentResponse3) consentResponse)
@@ -80,5 +87,10 @@ public class DomesticPaymentConsentResponseCalculation extends PaymentConsentRes
                     );
         }
         return consentResponse;
+    }
+
+    @Override
+    public List<OBError1> getErrors() {
+        return errors;
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
@@ -17,8 +17,14 @@ package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.cal
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
 import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.error.OBError1;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class PaymentConsentResponseCalculation {
+
+    protected List<OBError1> errors = new ArrayList<>();
 
     protected static final String DEFAULT_CHARGE_AMOUNT = "1.5";
     protected static final String DEFAULT_CHARGE_CURRENCY = "GBP";
@@ -40,6 +46,12 @@ public abstract class PaymentConsentResponseCalculation {
      * @param <R> dealing generic type
      */
     public abstract <T, R> R calculate(T consentRequest, R consentResponse);
+
+    /**
+     * Get the error events list to build the error response
+     * @return list of {@link OBError1}
+     */
+    public abstract List<OBError1> getErrors();
 
     /**
      * Get defaults amount of charges

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticPaymentConsentValidation.java
@@ -40,12 +40,13 @@ public class DomesticPaymentConsentValidation extends PaymentConsentValidation {
     }
 
     @Override
-    public <T> boolean validate(T consent) {
+    public <T> void validate(T consent) {
+        errors.clear();
         if (consent instanceof OBWriteDomesticConsent3) {
-            // TODO validate OBWriteDomesticConsent3
-            return true;
+            validateInstructedAmount(((OBWriteDomesticConsent3) consent).getData().getInitiation().getInstructedAmount());
+            return;
         }
-        // TODO validate OBWriteDomesticConsent4
-        return true;
+        validateInstructedAmount(((OBWriteDomesticConsent4) consent).getData().getInitiation().getInstructedAmount());
     }
+
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticScheduledPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticScheduledPaymentConsentValidation.java
@@ -39,12 +39,12 @@ public class DomesticScheduledPaymentConsentValidation extends PaymentConsentVal
     }
 
     @Override
-    public <T> boolean validate(T consent) {
+    public <T> void validate(T consent) {
+        errors.clear();
         if (consent instanceof OBWriteDomesticScheduledConsent3) {
-            // TODO validate OBWriteDomesticScheduledConsent3
-            return true;
+            validateInstructedAmount(((OBWriteDomesticScheduledConsent3) consent).getData().getInitiation().getInstructedAmount());
+            return;
         }
-        // TODO validate OBWriteDomesticScheduledConsent4
-        return true;
+        validateInstructedAmount(((OBWriteDomesticScheduledConsent4) consent).getData().getInitiation().getInstructedAmount());
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticStandingOrdersConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticStandingOrdersConsentValidation.java
@@ -16,8 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent5;
+import uk.org.openbanking.datamodel.payment.*;
 
 /**
  * Validation class for Domestic Payment consent request
@@ -39,12 +38,31 @@ public class DomesticStandingOrdersConsentValidation extends PaymentConsentValid
     }
 
     @Override
-    public <T> boolean validate(T consent) {
+    public <T> void validate(T consent) {
+        errors.clear();
         if (consent instanceof OBWriteDomesticStandingOrderConsent4) {
-            // TODO validate OBWriteDomesticStandingOrderConsent4
-            return true;
+            validate(((OBWriteDomesticStandingOrderConsent4) consent).getData().getInitiation().getFirstPaymentAmount());
+            validate(((OBWriteDomesticStandingOrderConsent4) consent).getData().getInitiation().getRecurringPaymentAmount());
+            validate(((OBWriteDomesticStandingOrderConsent4) consent).getData().getInitiation().getFinalPaymentAmount());
+            return;
         }
-        // TODO validate OBWriteDomesticStandingOrderConsent5
-        return true;
+        validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getFirstPaymentAmount());
+        validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getRecurringPaymentAmount());
+        validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getFinalPaymentAmount());
+    }
+
+    private void validate(OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount firstPaymentAmount) {
+        validateAmount(firstPaymentAmount.getAmount());
+        validateCurrency(firstPaymentAmount.getCurrency());
+    }
+
+    private void validate(OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount recurringPaymentAmount) {
+        validateAmount(recurringPaymentAmount.getAmount());
+        validateCurrency(recurringPaymentAmount.getCurrency());
+    }
+
+    private void validate(OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount finalPaymentAmount) {
+        validateAmount(finalPaymentAmount.getAmount());
+        validateCurrency(finalPaymentAmount.getCurrency());
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentConsentValidation.java
@@ -34,8 +34,9 @@ public class FilePaymentConsentValidation extends PaymentConsentValidation {
     }
 
     @Override
-    public <T> boolean validate(T consent) {
-        // TODO validate OBWriteFileConsent3
-        return true;
+    public <T> void validate(T consent) {
+        errors.clear();
+        validateNumberTransactions(((OBWriteFileConsent3) consent).getData().getInitiation().getNumberOfTransactions());
+        validateControlSum(((OBWriteFileConsent3) consent).getData().getInitiation().getControlSum());
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/GenericValidations.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/GenericValidations.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.validation;
+
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType;
+import com.forgerock.securebanking.openbanking.uk.rs.common.Currencies;
+import com.google.common.base.Strings;
+import uk.org.openbanking.datamodel.error.OBError1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational2DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Abstract class with default generic validation methods
+ */
+public abstract class GenericValidations {
+
+    protected List<OBError1> errors = new ArrayList<>();
+
+    private static final BigDecimal ZERO = new BigDecimal(0);
+
+    /**
+     * Get the error events list to build the error response
+     * @return list of {@link OBError1}
+     */
+    public List<OBError1> getErrors() {
+        return errors;
+    }
+
+    protected void validateInstructedAmount(OBWriteDomestic2DataInitiationInstructedAmount instructedAmount) {
+        if (isNull(instructedAmount, "InstructedAmount")) {
+            return;
+        }
+        validateAmount(instructedAmount.getAmount());
+        validateCurrency(instructedAmount.getCurrency());
+    }
+
+    protected void validateExchangeRateInformation(OBWriteInternational2DataInitiationExchangeRateInformation exchangeRateInformation) {
+        if (isNull(exchangeRateInformation, "ExchangeRateInformation")) {
+            return;
+        }
+        // TODO the validation
+        // exchangeRateInformation.getRateType();
+
+    }
+
+    protected void validateExchangeRateInformation(OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInformation) {
+        if (isNull(exchangeRateInformation, "ExchangeRateInformation")) {
+            return;
+        }
+        // TODO the validation
+        // exchangeRateInformation.getRateType();
+
+    }
+
+    protected void validateAmount(String amount) {
+        if (isNull(amount, "Amount")) {
+            return;
+        }
+        if (new BigDecimal(amount).compareTo(ZERO) <= 0) {
+            errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("The amount %s provided must be greater than 0", amount)
+            ));
+        }
+    }
+
+    protected void validateNumberTransactions(String numberOfTransactions) {
+        if (isNull(numberOfTransactions, "NumberOfTransactions")) {
+            return;
+        }
+        if (Double.parseDouble(numberOfTransactions) <= 0) {
+            errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("The numberOfTransactions %s must be greater than 0", numberOfTransactions)
+            ));
+        }
+    }
+
+    protected void validateControlSum(BigDecimal controlSum) {
+        if (isNull(controlSum, "ControlSum")) {
+            return;
+        }
+        if (controlSum.compareTo(ZERO) <= 0) {
+            errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("The numberOfTransactions %s must be greater than 0", controlSum)
+            ));
+        }
+    }
+
+    protected void validateCurrency(String currency) {
+        if (isNull(currency, "Currency")) {
+            return;
+        }
+        if (!Currencies.contains(currency)) {
+            errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("The currency %s provided is not supported.", currency)
+            ));
+        }
+    }
+
+    private boolean isNull(String value, String valueName) {
+        if (Strings.isNullOrEmpty(value)) {
+            errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("'%s' cannot be null to be validate", valueName)
+            ));
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isNull(Object object, String objectName) {
+        if (Objects.isNull(object)) {
+            errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                    String.format("'%s' cannot be null to be validate", objectName)
+            ));
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/GenericValidations.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/GenericValidations.java
@@ -110,7 +110,7 @@ public abstract class GenericValidations {
         }
         if (!Currencies.contains(currency)) {
             errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
-                    String.format("The currency %s provided is not supported.", currency)
+                    String.format("The currency %s provided is not supported", currency)
             ));
         }
     }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalPaymentConsentValidation.java
@@ -43,15 +43,19 @@ public class InternationalPaymentConsentValidation extends PaymentConsentValidat
     }
 
     @Override
-    public <T> boolean validate(T consent) {
+    public <T> void validate(T consent) {
+        errors.clear();
         if (consent instanceof OBWriteInternationalConsent3) {
-            // TODO validate OBWriteInternationalConsent3
-            return true;
+            validateInstructedAmount(((OBWriteInternationalConsent3) consent).getData().getInitiation().getInstructedAmount());
+            validateExchangeRateInformation(((OBWriteInternationalConsent3) consent).getData().getInitiation().getExchangeRateInformation());
+            return;
         } else if (consent instanceof OBWriteInternationalConsent4) {
-            // TODO validate OBWriteInternationalConsent4
-            return true;
+            validateInstructedAmount(((OBWriteInternationalConsent4) consent).getData().getInitiation().getInstructedAmount());
+            validateExchangeRateInformation(((OBWriteInternationalConsent4) consent).getData().getInitiation().getExchangeRateInformation());
+            return;
         }
-        // TODO validate OBWriteInternationalConsent5
-        return true;
+        validateInstructedAmount(((OBWriteInternationalConsent5) consent).getData().getInitiation().getInstructedAmount());
+        validateExchangeRateInformation(((OBWriteInternationalConsent5) consent).getData().getInitiation().getExchangeRateInformation());
     }
+
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalScheduledPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalScheduledPaymentConsentValidation.java
@@ -44,14 +44,18 @@ public class InternationalScheduledPaymentConsentValidation extends PaymentConse
     }
 
     @Override
-    public <T> boolean validate(T consent) {
+    public <T> void validate(T consent) {
+        errors.clear();
         if (consent instanceof OBWriteInternationalScheduledConsent3) {
-            // TODO validate OBWriteInternationalScheduledConsent3
-            return true;
+            validateInstructedAmount(((OBWriteInternationalScheduledConsent3) consent).getData().getInitiation().getInstructedAmount());
+            validateExchangeRateInformation(((OBWriteInternationalScheduledConsent3) consent).getData().getInitiation().getExchangeRateInformation());
+            return;
         } else if (consent instanceof OBWriteInternationalScheduledConsent4) {
-            // TODO validate OBWriteInternationalScheduledConsent4
+            validateInstructedAmount(((OBWriteInternationalScheduledConsent4) consent).getData().getInitiation().getInstructedAmount());
+            validateExchangeRateInformation(((OBWriteInternationalScheduledConsent4) consent).getData().getInitiation().getExchangeRateInformation());
+            return;
         }
-        // TODO validate OBWriteInternationalScheduledConsent5
-        return true;
+        validateInstructedAmount(((OBWriteInternationalScheduledConsent5) consent).getData().getInitiation().getInstructedAmount());
+        validateExchangeRateInformation(((OBWriteInternationalScheduledConsent5) consent).getData().getInitiation().getExchangeRateInformation());
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalStandingOrdersConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalStandingOrdersConsentValidation.java
@@ -44,14 +44,15 @@ public class InternationalStandingOrdersConsentValidation extends PaymentConsent
     }
 
     @Override
-    public <T> boolean validate(T consent) {
+    public <T> void validate(T consent) {
+        errors.clear();
         if (consent instanceof OBWriteInternationalStandingOrderConsent4) {
-            // TODO validate OBWriteInternationalStandingOrderConsent4
-            return true;
+            validateInstructedAmount(((OBWriteInternationalStandingOrderConsent4) consent).getData().getInitiation().getInstructedAmount());
+            return;
         } else if (consent instanceof OBWriteInternationalStandingOrderConsent5) {
-            // TODO validate OBWriteInternationalStandingOrderConsent5
+            validateInstructedAmount(((OBWriteInternationalStandingOrderConsent5) consent).getData().getInitiation().getInstructedAmount());
+            return;
         }
-        // TODO validate OBWriteInternationalStandingOrderConsent6
-        return true;
+        validateInstructedAmount(((OBWriteInternationalStandingOrderConsent6) consent).getData().getInitiation().getInstructedAmount());
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidation.java
@@ -17,7 +17,8 @@ package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.val
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
 
-public abstract class PaymentConsentValidation {
+public abstract class PaymentConsentValidation extends GenericValidations {
+
     /**
      *
      * @param version {@link OBVersion} is the api version to identify the request object to be validated
@@ -28,8 +29,8 @@ public abstract class PaymentConsentValidation {
     /**
      *
      * @param consent the consent request object
-     * @return true if the validation passed, false otherwise
      * @param <T> dealing generic type
      */
-    public abstract <T> boolean validate(T consent);
+    public abstract <T> void validate(T consent);
+
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/Currencies.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/Currencies.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.common;
+
+/**
+ * Enum to ISO 4217 "Codes for the representation of currencies supported by SBAT"
+ */
+public enum Currencies {
+    AED("AED", "United Arab Emirates Dirham"),
+    AFN("AFN", "Afghanistan Afghani"),
+    ALL("ALL", "Albania Lek"),
+    AMD("AMD", "Armenia Dram"),
+    ANG("ANG", "Netherlands Antilles Guilder"),
+    AOA("AOA", "Angola Kwanza"),
+    ARS("ARS", "Argentina Peso"),
+    AUD("AUD", "Australia Dollar"),
+    AWG("AWG", "Aruba Guilder"),
+    AZN("AZN", "Azerbaijan Manat"),
+    BAM("BAM", "Bosnia and Herzegovina Convertible Mark"),
+    BBD("BBD", "Barbados Dollar"),
+    BDT("BDT", "Bangladesh Taka"),
+    BGN("BGN", "Bulgaria Lev"),
+    BHD("BHD", "Bahrain Dinar"),
+    BIF("BIF", "Burundi Franc"),
+    BMD("BMD", "Bermuda Dollar"),
+    BND("BND", "Brunei Darussalam Dollar"),
+    BOB("BOB", "Bolivia Bolíviano"),
+    BRL("BRL", "Brazil Real"),
+    BSD("BSD", "Bahamas Dollar"),
+    BTN("BTN", "Bhutan Ngultrum"),
+    BWP("BWP", "Botswana Pula"),
+    BYN("BYN", "Belarus Ruble"),
+    BZD("BZD", "Belize Dollar"),
+    CAD("CAD", "Canada Dollar"),
+    CDF("CDF", "Congo/Kinshasa Franc"),
+    CHF("CHF", "Switzerland Franc"),
+    CLP("CLP", "Chile Peso"),
+    CNY("CNY", "China Yuan Renminbi"),
+    COP("COP", "Colombia Peso"),
+    CRC("CRC", "Costa Rica Colon"),
+    CUC("CUC", "Cuba Convertible Peso"),
+    CUP("CUP", "Cuba Peso"),
+    CVE("CVE", "Cape Verde Escudo"),
+    CZK("CZK", "Czech Republic Koruna"),
+    DJF("DJF", "Djibouti Franc"),
+    DKK("DKK", "Denmark Krone"),
+    DOP("DOP", "Dominican Republic Peso"),
+    DZD("DZD", "Algeria Dinar"),
+    EGP("EGP", "Egypt Pound"),
+    ERN("ERN", "Eritrea Nakfa"),
+    ETB("ETB", "Ethiopia Birr"),
+    EUR("EUR", "Euro Member Countries"),
+    FJD("FJD", "Fiji Dollar"),
+    FKP("FKP", "Falkland Islands (Malvinas) Pound)"),
+    GBP("GBP", "United Kingdom Pound"),
+    GEL("GEL", "Georgia Lari"),
+    GGP("GGP", "Guernsey Pound"),
+    GHS("GHS", "Ghana Cedi"),
+    GIP("GIP", "Gibraltar Pound"),
+    GMD("GMD", "Gambia Dalasi"),
+    GNF("GNF", "Guinea Franc"),
+    GTQ("GTQ", "Guatemala Quetzal"),
+    GYD("GYD", "Guyana Dollar"),
+    HKD("HKD", "Hong Kong Dollar"),
+    HNL("HNL", "Honduras Lempira"),
+    HRK("HRK", "Croatia Kuna"),
+    HTG("HTG", "Haiti Gourde"),
+    HUF("HUF", "Hungary Forint"),
+    IDR("IDR", "Indonesia Rupiah"),
+    ILS("ILS", "Israel Shekel"),
+    IMP("IMP", "Isle of Man Pound"),
+    INR("INR", "India Rupee"),
+    IQD("IQD", "Iraq Dinar"),
+    IRR("IRR", "Iran Rial"),
+    ISK("ISK", "Iceland Krona"),
+    JEP("JEP", "Jersey Pound"),
+    JMD("JMD", "Jamaica Dollar"),
+    JOD("JOD", "Jordan Dinar"),
+    JPY("JPY", "Japan Yen"),
+    KES("KES", "Kenya Shilling"),
+    KGS("KGS", "Kyrgyzstan Som"),
+    KHR("KHR", "Cambodia Riel"),
+    KMF("KMF", "Comorian Franc"),
+    KPW("KPW", "Korea (North) Won"),
+    KRW("KRW", "Korea (South) Won"),
+    KWD("KWD", "Kuwait Dinar"),
+    KYD("KYD", "Cayman Islands Dollar"),
+    KZT("KZT", "Kazakhstan Tenge"),
+    LAK("LAK", "Laos Kip"),
+    LBP("LBP", "Lebanon Pound"),
+    LKR("LKR", "Sri Lanka Rupee"),
+    LRD("LRD", "Liberia Dollar"),
+    LSL("LSL", "Lesotho Loti"),
+    LYD("LYD", "Libya Dinar"),
+    MAD("MAD", "Morocco Dirham"),
+    MDL("MDL", "Moldova Leu"),
+    MGA("MGA", "Madagascar Ariary"),
+    MKD("MKD", "Macedonia Denar"),
+    MMK("MMK", "Myanmar (Burma) Kyat"),
+    MNT("MNT", "Mongolia Tughrik"),
+    MOP("MOP", "Macau Pataca"),
+    MRU("MRU", "Mauritania Ouguiya"),
+    MUR("MUR", "Mauritius Rupee"),
+    MVR("MVR", "Maldives (Maldive Islands) Rufiyaa"),
+    MWK("MWK", "Malawi Kwacha"),
+    MXN("MXN", "Mexico Peso"),
+    MYR("MYR", "Malaysia Ringgit"),
+    MZN("MZN", "Mozambique Metical"),
+    NAD("NAD", "Namibia Dollar"),
+    NGN("NGN", "Nigeria Naira"),
+    NIO("NIO", "Nicaragua Cordoba"),
+    NOK("NOK", "Norway Krone"),
+    NPR("NPR", "Nepal Rupee"),
+    NZD("NZD", "New Zealand Dollar"),
+    OMR("OMR", "Oman Rial"),
+    PAB("PAB", "Panama Balboa"),
+    PEN("PEN", "Peru Sol"),
+    PGK("PGK", "Papua New Guinea Kina"),
+    PHP("PHP", "Philippines Peso"),
+    PKR("PKR", "Pakistan Rupee"),
+    PLN("PLN", "Poland Zloty"),
+    PYG("PYG", "Paraguay Guarani"),
+    QAR("QAR", "Qatar Riyal"),
+    RON("RON", "Romania Leu"),
+    RSD("RSD", "Serbia Dinar"),
+    RUB("RUB", "Russia Ruble"),
+    RWF("RWF", "Rwanda Franc"),
+    SAR("SAR", "Saudi Arabia Riyal"),
+    SBD("SBD", "Solomon Islands Dollar"),
+    SCR("SCR", "Seychelles Rupee"),
+    SDG("SDG", "Sudan Pound"),
+    SEK("SEK", "Sweden Krona"),
+    SGD("SGD", "Singapore Dollar"),
+    SHP("SHP", "Saint Helena Pound"),
+    SLL("SLL", "Sierra Leone Leone"),
+    SOS("SOS", "Somalia Shilling"),
+    SPL("SPL", "Seborga Luigino"),
+    SRD("SRD", "Suriname Dollar"),
+    STN("STN", "São Tomé and Príncipe Dobra"),
+    SVC("SVC", "El Salvador Colon"),
+    SYP("SYP", "Syria Pound"),
+    SZL("SZL", "eSwatini Lilangeni"),
+    THB("THB", "Thailand Baht"),
+    TJS("TJS", "Tajikistan Somoni"),
+    TMT("TMT", "Turkmenistan Manat"),
+    TND("TND", "Tunisia Dinar"),
+    TOP("TOP", "Tonga Pa'anga"),
+    TRY("TRY", "Turkey Lira"),
+    TTD("TTD", "Trinidad and Tobago Dollar"),
+    TVD("TVD", "Tuvalu Dollar"),
+    TWD("TWD", "Taiwan New Dollar"),
+    TZS("TZS", "Tanzania Shilling"),
+    UAH("UAH", "Ukraine Hryvnia"),
+    UGX("UGX", "Uganda Shilling"),
+    USD("USD", "United States Dollar"),
+    UYU("UYU", "Uruguay Peso"),
+    UZS("UZS", "Uzbekistan Som"),
+    VEF("VEF", "Venezuela Bolívar"),
+    VND("VND", "Viet Nam Dong"),
+    VUV("VUV", "Vanuatu Vatu"),
+    WST("WST", "Samoa Tala"),
+    XAF("XAF", "Communauté Financière Africaine (BEAC) CFA Franc BEAC"),
+    XCD("XCD", "East Caribbean Dollar"),
+    XDR("XDR", "International Monetary Fund (IMF) Special Drawing Rights"),
+    XOF("XOF", "Communauté Financière Africaine (BCEAO) Franc"),
+    XPF("XPF", "Comptoirs Français du Pacifique(CFP) Franc"),
+    YER("YER", "Yemen Rial"),
+    ZAR("ZAR", "South Africa Rand"),
+    ZMW("ZMW", "Zambia Kwacha"),
+    ZWD("ZWD", "Zimbabwe Dollar");
+
+    private String code;
+    private String description;
+
+    Currencies(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public static boolean contains(String currency) {
+        for (Currencies c : Currencies.values()) {
+            if (c.code.equals(currency)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsControllerTest.java
@@ -35,7 +35,8 @@ import uk.org.openbanking.datamodel.payment.*;
 
 import java.net.URI;
 
-import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.*;
+import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.API_VERSION_DESCRIPTION;
+import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.INTENT_TYPE_DESCRIPTION;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredBackofficeHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -141,9 +142,11 @@ public class CalculateResponseElementsControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
         assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
-        OBError1 error = response.getBody().getErrors().get(0);
-        assertThat(error.getErrorCode()).isEqualTo(OBRIErrorType.DATA_INVALID_REQUEST.getCode().getValue());
-        assertThat(error.getMessage()).contains(String.format("It has not been possible to determine the value of '%s'", API_VERSION_DESCRIPTION));
+        assertThat(response.getBody().getErrors()).containsExactly(
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("It has not been possible to determine the value of '%s'", API_VERSION_DESCRIPTION)
+                )
+        );
     }
 
     @Test
@@ -161,9 +164,11 @@ public class CalculateResponseElementsControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
         assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
-        OBError1 error = response.getBody().getErrors().get(0);
-        assertThat(error.getErrorCode()).isEqualTo(OBRIErrorType.DATA_INVALID_REQUEST.getCode().getValue());
-        assertThat(error.getMessage()).contains(String.format("It has not been possible to determine the value of '%s'", INTENT_TYPE_DESCRIPTION));
+        assertThat(response.getBody().getErrors()).containsExactly(
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("It has not been possible to determine the value of '%s'", INTENT_TYPE_DESCRIPTION)
+                )
+        );
     }
 
     @Test
@@ -182,9 +187,11 @@ public class CalculateResponseElementsControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
         assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
-        OBError1 error = response.getBody().getErrors().get(0);
-        assertThat(error.getErrorCode()).isEqualTo(OBRIErrorType.DATA_INVALID_REQUEST.getCode().getValue());
-        assertThat(error.getMessage()).contains(String.format("'%s' cannot be null to be validate", "InstructedAmount"));
+        assertThat(response.getBody().getErrors()).containsExactly(
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format(String.format("'%s' cannot be null to be validate", "InstructedAmount"))
+                )
+        );
     }
 
     @Test
@@ -203,10 +210,13 @@ public class CalculateResponseElementsControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
         assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
-        OBError1 error = response.getBody().getErrors().get(0);
-        assertThat(error.getErrorCode()).isEqualTo(OBRIErrorType.DATA_INVALID_REQUEST.getCode().getValue());
-        assertThat(error.getMessage()).contains(
-                String.format("The amount %s provided must be greater than 0", consentRequest.getData().getInitiation().getInstructedAmount().getAmount())
+        assertThat(response.getBody().getErrors()).containsExactly(
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format(
+                                "The amount %s provided must be greater than 0",
+                                consentRequest.getData().getInitiation().getInstructedAmount().getAmount()
+                        )
+                )
         );
     }
 
@@ -226,10 +236,46 @@ public class CalculateResponseElementsControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
         assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
-        OBError1 error = response.getBody().getErrors().get(0);
-        assertThat(error.getErrorCode()).isEqualTo(OBRIErrorType.DATA_INVALID_REQUEST.getCode().getValue());
-        assertThat(error.getMessage()).contains(
-                String.format("The currency %s provided is not supported.", consentRequest.getData().getInitiation().getInstructedAmount().getCurrency())
+        assertThat(response.getBody().getErrors()).containsExactly(
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format(
+                                "The currency %s provided is not supported",
+                                consentRequest.getData().getInitiation().getInstructedAmount().getCurrency()
+                        )
+                )
+        );
+    }
+
+    @Test
+    public void shouldFailsInstructedAmountAmountAndCurrency() throws JsonProcessingException {
+        String intent = IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId();
+        OBWriteDomesticConsent4 consentRequest = aValidOBWriteDomesticConsent4();
+        consentRequest.getData().getInitiation().getInstructedAmount().setAmount("0");
+        consentRequest.getData().getInitiation().getInstructedAmount().setCurrency("BITCOIN");
+        // When
+        ResponseEntity<OBErrorResponse1> response = restTemplate.exchange(
+                getUri(intent, OBVersion.v3_1_8.getCanonicalName()),
+                HttpMethod.POST,
+                new HttpEntity<>(mapper.writeValueAsString(consentRequest), HTTP_HEADERS),
+                OBErrorResponse1.class);
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().getCode()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getId());
+        assertThat(response.getBody().getMessage()).isEqualTo(OBRIErrorResponseCategory.REQUEST_INVALID.getDescription());
+        assertThat(response.getBody().getErrors()).containsExactlyInAnyOrder(
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format(
+                                "The currency %s provided is not supported",
+                                consentRequest.getData().getInitiation().getInstructedAmount().getCurrency()
+                        )
+                ),
+                OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format(
+                                "The amount %s provided must be greater than 0",
+                                consentRequest.getData().getInitiation().getInstructedAmount().getAmount()
+                        )
+                )
         );
     }
 


### PR DESCRIPTION
- Implement pattern to manage the error list for validations
- Improvements in controller to avoid throw internal exceptions when error event happens
- Completion of domestic payments consent request validation test coverage
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/432