### PR TITLE
442: Implement handling exceptions to reject the consent

### DIFF
--- a/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElements.java
+++ b/securebanking-openbanking-uk-rs-backoffice-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElements.java
@@ -33,7 +33,13 @@ public interface CalculateResponseElements {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Response elements successfully calculated", response = String.class),
             @ApiResponse(code = 400, message = "Bad request", response = OBErrorResponse1.class),
-            @ApiResponse(code = 403, message = "Validation failed", response = OBErrorResponse1.class)
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 403, message = "Validation failed", response = OBErrorResponse1.class),
+            @ApiResponse(code = 404, message = "Not found"),
+            @ApiResponse(code = 405, message = "Method Not Allowed"),
+            @ApiResponse(code = 406, message = "Not Acceptable"),
+            @ApiResponse(code = 429, message = "Too Many Requests"),
+            @ApiResponse(code = 500, message = "Internal Server Error", response = OBErrorResponse1.class)
     })
     @RequestMapping(value = "/calculate-elements",
             produces = {"application/json; charset=utf-8"},

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsController.java
@@ -43,7 +43,7 @@ public class CalculateResponseElementsController implements CalculateResponseEle
     public static final String VALIDATION_TEST_FAILURE_HEADER = "x-validation-test-failure";
     public static final String API_VERSION_DESCRIPTION = "Api version";
     public static final String INTENT_TYPE_DESCRIPTION = "Intent type";
-    public static CustomObjectMapper customObjectMapper;
+    private final CustomObjectMapper customObjectMapper;
 
     public CalculateResponseElementsController() {
         customObjectMapper = CustomObjectMapper.getCustomObjectMapper();
@@ -69,7 +69,7 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             log.debug("{}, Consent request\n {}", xFapiFinancialId, body);
 
             PaymentConsentValidation validation = PaymentConsentValidationFactory.getValidationInstance(intent);
-            Object consentRequest = CustomObjectMapper.getObjectMapper().readValue(body, validation.getRequestClass(apiVersion));
+            Object consentRequest = customObjectMapper.getObjectMapper().readValue(body, validation.getRequestClass(apiVersion));
             validation.validate(consentRequest);
 
             if (haveErrorEvents(validation.getErrors(), xFapiFinancialId)) {
@@ -89,7 +89,7 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             log.debug("{}, Calculation done for intent {} version {}", xFapiFinancialId, intentType, apiVersion.getCanonicalName());
             log.debug("{}, Sending the response {}", xFapiFinancialId, customObjectMapper.getObjectMapper().writeValueAsString(consentEntityResponse));
 
-            return ResponseEntity.ok(consentEntityResponse);
+            return ResponseEntity.ok(customObjectMapper.getObjectMapper().writeValueAsString(consentEntityResponse));
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
@@ -96,7 +96,7 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                                     .exchangeRate(EXCHANGE_RATE)
                                     .rateType(rateType)
                                     .unitCurrency(((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
-                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                                    .expirationDateTime(DateTime.now().plusMinutes(5))
                     );
                 }
                 case INDICATIVE -> {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
@@ -47,7 +47,6 @@ import java.util.List;
 public class InternationalPaymentConsentResponseCalculation extends PaymentConsentResponseCalculation {
 
     public static final String TYPE = "UK.OBIE.CHAPSOut";
-    public static final BigDecimal EXCHANGE_RATE = BigDecimal.valueOf(1.25);
 
     @Override
     public Class getResponseClass(OBVersion version) {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
@@ -23,7 +23,7 @@ import org.joda.time.DateTime;
 import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.*;
-import java.math.BigDecimal;
+
 import java.util.List;
 
 /**

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalPaymentConsentResponseCalculation.java
@@ -16,12 +16,14 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.calculation;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType;
 import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils.DefaultData;
 import lombok.extern.slf4j.Slf4j;
+import org.joda.time.DateTime;
 import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.*;
-
+import java.math.BigDecimal;
 import java.util.List;
 
 /**
@@ -41,11 +43,11 @@ import java.util.List;
  *     </li>
  * </ul>
  */
-@SuppressWarnings("unchecked")
 @Slf4j
 public class InternationalPaymentConsentResponseCalculation extends PaymentConsentResponseCalculation {
 
     public static final String TYPE = "UK.OBIE.CHAPSOut";
+    public static final BigDecimal EXCHANGE_RATE = BigDecimal.valueOf(1.25);
 
     @Override
     public Class getResponseClass(OBVersion version) {
@@ -74,6 +76,7 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                                     .type(TYPE)
                                     .amount(getDefaultAmount())
                     );
+
             if (((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation() == null) {
                 log.debug("OBWriteInternationalConsentResponse3 instance uses default exchangeRate");
                 ((OBWriteInternationalConsentResponse3) consentResponse)
@@ -81,9 +84,42 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                         getInitiation()
                         .setExchangeRateInformation(
                                 DefaultData.defaultOBWriteInternational2DataInitiationExchangeRateInformation(
-                                        ((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency(),
                                         ((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getCurrencyOfTransfer())
                         );
+            }
+
+            OBExchangeRateType2Code rateType = ((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
+            switch (rateType) {
+                case ACTUAL -> {
+                    ((OBWriteInternationalConsentResponse3) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse3DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                    );
+                }
+                case INDICATIVE -> {
+                    ((OBWriteInternationalConsentResponse3) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse3DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                    );
+
+                }
+                case AGREED -> {
+                    ((OBWriteInternationalConsentResponse3) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse3DataExchangeRateInformation()
+                                    .exchangeRate(((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getExchangeRate())
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .contractIdentification(((OBWriteInternationalConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getContractIdentification())
+                    );
+                }
+                default -> errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("The rate type %s provided isn't valid", rateType)
+                ));
             }
 
         } else if (consentResponse instanceof OBWriteInternationalConsentResponse4) {
@@ -96,6 +132,7 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                                     .type(TYPE)
                                     .amount(getDefaultAmount())
                     );
+
             if (((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation() == null) {
                 log.debug("OBWriteInternationalConsentResponse4 instance uses default exchangeRate");
                 ((OBWriteInternationalConsentResponse4) consentResponse)
@@ -103,9 +140,42 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                         getInitiation()
                         .setExchangeRateInformation(
                                 DefaultData.defaultOBWriteInternational3DataInitiationExchangeRateInformation(
-                                        ((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency(),
                                         ((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getCurrencyOfTransfer())
                         );
+            }
+
+            OBExchangeRateType2Code rateType = ((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
+            switch (rateType) {
+                case ACTUAL -> {
+                    ((OBWriteInternationalConsentResponse4) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse4DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                    );
+                }
+                case INDICATIVE -> {
+                    ((OBWriteInternationalConsentResponse4) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse4DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                    );
+
+                }
+                case AGREED -> {
+                    ((OBWriteInternationalConsentResponse4) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse4DataExchangeRateInformation()
+                                    .exchangeRate(((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getExchangeRate())
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .contractIdentification(((OBWriteInternationalConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getContractIdentification())
+                    );
+                }
+                default -> errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("The rate type %s provided isn't valid", rateType)
+                ));
             }
 
         } else if (consentResponse instanceof OBWriteInternationalConsentResponse5) {
@@ -126,9 +196,42 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                         getInitiation()
                         .setExchangeRateInformation(
                                 DefaultData.defaultOBWriteInternational3DataInitiationExchangeRateInformation(
-                                        ((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency(),
                                         ((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getCurrencyOfTransfer())
                         );
+            }
+
+            OBExchangeRateType2Code rateType = ((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
+            switch (rateType) {
+                case ACTUAL -> {
+                    ((OBWriteInternationalConsentResponse5) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse5DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                    );
+                }
+                case INDICATIVE -> {
+                    ((OBWriteInternationalConsentResponse5) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse5DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                    );
+
+                }
+                case AGREED -> {
+                    ((OBWriteInternationalConsentResponse5) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse5DataExchangeRateInformation()
+                                    .exchangeRate(((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getExchangeRate())
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .contractIdentification(((OBWriteInternationalConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getContractIdentification())
+                    );
+                }
+                default -> errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("The rate type %s provided isn't valid", rateType)
+                ));
             }
 
         } else {
@@ -149,9 +252,42 @@ public class InternationalPaymentConsentResponseCalculation extends PaymentConse
                         getInitiation()
                         .setExchangeRateInformation(
                                 DefaultData.defaultOBWriteInternational3DataInitiationExchangeRateInformation(
-                                        ((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency(),
                                         ((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getCurrencyOfTransfer())
                         );
+            }
+
+            OBExchangeRateType2Code rateType = ((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
+            switch (rateType) {
+                case ACTUAL -> {
+                    ((OBWriteInternationalConsentResponse6) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse6DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                    );
+                }
+                case INDICATIVE -> {
+                    ((OBWriteInternationalConsentResponse6) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse6DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                    );
+
+                }
+                case AGREED -> {
+                    ((OBWriteInternationalConsentResponse6) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse6DataExchangeRateInformation()
+                                    .exchangeRate(((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getExchangeRate())
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .contractIdentification(((OBWriteInternationalConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getContractIdentification())
+                    );
+                }
+                default -> errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("The rate type %s provided isn't valid", rateType)
+                ));
             }
         }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalScheduledPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalScheduledPaymentConsentResponseCalculation.java
@@ -48,8 +48,6 @@ import java.util.List;
 public class InternationalScheduledPaymentConsentResponseCalculation extends PaymentConsentResponseCalculation {
 
     public static final String TYPE = "UK.OBIE.CHAPSOut";
-    public static final BigDecimal EXCHANGE_RATE = BigDecimal.valueOf(1.25);
-
     @Override
     public Class getResponseClass(OBVersion version) {
         log.debug("{} is the version to calculate response elements", version.getCanonicalName());

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalScheduledPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalScheduledPaymentConsentResponseCalculation.java
@@ -16,12 +16,14 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.calculation;
 
 import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion;
+import com.forgerock.securebanking.openbanking.uk.error.OBRIErrorType;
 import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils.DefaultData;
 import lombok.extern.slf4j.Slf4j;
+import org.joda.time.DateTime;
 import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.*;
-
+import java.math.BigDecimal;
 import java.util.List;
 
 /**
@@ -46,6 +48,7 @@ import java.util.List;
 public class InternationalScheduledPaymentConsentResponseCalculation extends PaymentConsentResponseCalculation {
 
     public static final String TYPE = "UK.OBIE.CHAPSOut";
+    public static final BigDecimal EXCHANGE_RATE = BigDecimal.valueOf(1.25);
 
     @Override
     public Class getResponseClass(OBVersion version) {
@@ -82,9 +85,42 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                         getInitiation()
                         .setExchangeRateInformation(
                                 DefaultData.defaultOBWriteInternational2DataInitiationExchangeRateInformation(
-                                        ((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency(),
                                         ((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getCurrencyOfTransfer())
                         );
+            }
+
+            OBExchangeRateType2Code rateType = ((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
+            switch (rateType) {
+                case ACTUAL -> {
+                    ((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse3DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                    );
+                }
+                case INDICATIVE -> {
+                    ((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse3DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                    );
+
+                }
+                case AGREED -> {
+                    ((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse3DataExchangeRateInformation()
+                                    .exchangeRate(((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getExchangeRate())
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .contractIdentification(((OBWriteInternationalScheduledConsentResponse3) consentResponse).getData().getInitiation().getExchangeRateInformation().getContractIdentification())
+                    );
+                }
+                default -> errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("The rate type %s provided isn't valid", rateType)
+                ));
             }
 
         } else if (consentResponse instanceof OBWriteInternationalScheduledConsentResponse4) {
@@ -105,9 +141,42 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                         getInitiation()
                         .setExchangeRateInformation(
                                 DefaultData.defaultOBWriteInternational3DataInitiationExchangeRateInformation(
-                                        ((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency(),
                                         ((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getCurrencyOfTransfer())
                         );
+            }
+
+            OBExchangeRateType2Code rateType = ((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
+            switch (rateType) {
+                case ACTUAL -> {
+                    ((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse4DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                    );
+                }
+                case INDICATIVE -> {
+                    ((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse4DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                    );
+
+                }
+                case AGREED -> {
+                    ((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse4DataExchangeRateInformation()
+                                    .exchangeRate(((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getExchangeRate())
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .contractIdentification(((OBWriteInternationalScheduledConsentResponse4) consentResponse).getData().getInitiation().getExchangeRateInformation().getContractIdentification())
+                    );
+                }
+                default -> errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("The rate type %s provided isn't valid", rateType)
+                ));
             }
 
         } else if (consentResponse instanceof OBWriteInternationalScheduledConsentResponse5) {
@@ -128,13 +197,45 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                         getInitiation()
                         .setExchangeRateInformation(
                                 DefaultData.defaultOBWriteInternational3DataInitiationExchangeRateInformation(
-                                        ((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency(),
                                         ((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getCurrencyOfTransfer())
                         );
             }
 
-        }
-        else {
+            OBExchangeRateType2Code rateType = ((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
+            switch (rateType) {
+                case ACTUAL -> {
+                    ((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse5DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                    );
+                }
+                case INDICATIVE -> {
+                    ((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse5DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                    );
+
+                }
+                case AGREED -> {
+                    ((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse5DataExchangeRateInformation()
+                                    .exchangeRate(((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getExchangeRate())
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .contractIdentification(((OBWriteInternationalScheduledConsentResponse5) consentResponse).getData().getInitiation().getExchangeRateInformation().getContractIdentification())
+                    );
+                }
+                default -> errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("The rate type %s provided isn't valid", rateType)
+                ));
+            }
+
+        } else {
             log.debug("OBWriteInternationalScheduledConsentResponse6 instance");
             ((OBWriteInternationalScheduledConsentResponse6) consentResponse)
                     .getData()
@@ -152,9 +253,42 @@ public class InternationalScheduledPaymentConsentResponseCalculation extends Pay
                         getInitiation()
                         .setExchangeRateInformation(
                                 DefaultData.defaultOBWriteInternational3DataInitiationExchangeRateInformation(
-                                        ((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getInstructedAmount().getCurrency(),
                                         ((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getCurrencyOfTransfer())
                         );
+            }
+
+            OBExchangeRateType2Code rateType = ((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getRateType();
+            switch (rateType) {
+                case ACTUAL -> {
+                    ((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse6DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .expirationDateTime(DateTime.now().plusMinutes(10))
+                    );
+                }
+                case INDICATIVE -> {
+                    ((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse6DataExchangeRateInformation()
+                                    .exchangeRate(EXCHANGE_RATE)
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                    );
+
+                }
+                case AGREED -> {
+                    ((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().setExchangeRateInformation(
+                            new OBWriteInternationalConsentResponse6DataExchangeRateInformation()
+                                    .exchangeRate(((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getExchangeRate())
+                                    .rateType(rateType)
+                                    .unitCurrency(((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getUnitCurrency())
+                                    .contractIdentification(((OBWriteInternationalScheduledConsentResponse6) consentResponse).getData().getInitiation().getExchangeRateInformation().getContractIdentification())
+                    );
+                }
+                default -> errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
+                        String.format("The rate type %s provided isn't valid", rateType)
+                ));
             }
         }
         return consentResponse;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalScheduledPaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalScheduledPaymentConsentResponseCalculation.java
@@ -23,7 +23,7 @@ import org.joda.time.DateTime;
 import uk.org.openbanking.datamodel.common.OBChargeBearerType1Code;
 import uk.org.openbanking.datamodel.error.OBError1;
 import uk.org.openbanking.datamodel.payment.*;
-import java.math.BigDecimal;
+
 import java.util.List;
 
 /**
@@ -48,6 +48,7 @@ import java.util.List;
 public class InternationalScheduledPaymentConsentResponseCalculation extends PaymentConsentResponseCalculation {
 
     public static final String TYPE = "UK.OBIE.CHAPSOut";
+
     @Override
     public Class getResponseClass(OBVersion version) {
         log.debug("{} is the version to calculate response elements", version.getCanonicalName());

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalStandingOrderConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/InternationalStandingOrderConsentResponseCalculation.java
@@ -93,8 +93,7 @@ public class InternationalStandingOrderConsentResponseCalculation extends Paymen
                                     .type(TYPE)
                                     .amount(getDefaultAmount())
                     );
-        }
-        else {
+        } else {
             log.debug("OBWriteInternationalStandingOrderConsentResponse7 instance");
             ((OBWriteInternationalStandingOrderConsentResponse7) consentResponse)
                     .getData()

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
@@ -34,7 +34,6 @@ public abstract class PaymentConsentResponseCalculation {
 
 
     /**
-     *
      * @param version {@link OBVersion} is the api version to identify the response object to be built
      * @return the request consent class by version
      */
@@ -42,23 +41,24 @@ public abstract class PaymentConsentResponseCalculation {
 
 
     /**
-     *
-     * @param consentRequest consent request object
+     * @param consentRequest  consent request object
      * @param consentResponse consent response object
+     * @param <T>             dealing generic type
+     * @param <R>             dealing generic type
      * @return the consent response object with calculated elements
-     * @param <T> dealing generic type
-     * @param <R> dealing generic type
      */
     public abstract <T, R> R calculate(T consentRequest, R consentResponse);
 
     /**
      * Get the error events list to build the error response
+     *
      * @return list of {@link OBError1}
      */
     public abstract List<OBError1> getErrors();
 
     /**
      * Get defaults amount of charges
+     *
      * @return {@link OBActiveOrHistoricCurrencyAndAmount}
      */
     protected OBActiveOrHistoricCurrencyAndAmount getDefaultAmount() {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculation.java
@@ -19,6 +19,7 @@ import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 import uk.org.openbanking.datamodel.common.OBActiveOrHistoricCurrencyAndAmount;
 import uk.org.openbanking.datamodel.error.OBError1;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +29,9 @@ public abstract class PaymentConsentResponseCalculation {
 
     protected static final String DEFAULT_CHARGE_AMOUNT = "1.5";
     protected static final String DEFAULT_CHARGE_CURRENCY = "GBP";
+
+    public static final BigDecimal EXCHANGE_RATE = BigDecimal.valueOf(1.25);
+
 
     /**
      *

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculationFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/calculation/PaymentConsentResponseCalculationFactory.java
@@ -21,6 +21,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.vali
 public class PaymentConsentResponseCalculationFactory {
     /**
      * Get the calculation instance by consent type
+     *
      * @param consentId
      * @return a {@link PaymentConsentValidation} implementation instance
      */

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/CustomObjectMapper.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/CustomObjectMapper.java
@@ -1,5 +1,5 @@
-/**
- * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+/*
+ * Copyright © 2020-2022 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/CustomObjectMapper.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/CustomObjectMapper.java
@@ -33,7 +33,6 @@ import uk.org.openbanking.jackson.DateTimeSerializer;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 
 public class CustomObjectMapper {
     private static CustomObjectMapper customObjectMapper;

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/CustomObjectMapper.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/CustomObjectMapper.java
@@ -44,7 +44,7 @@ public class CustomObjectMapper {
                 jacksonObjectMapperBuilder -> {
                     jacksonObjectMapperBuilder.featuresToEnable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
                     jacksonObjectMapperBuilder.serializerByType(BigDecimal.class, new Min2DecimalPlacesBigDecimalSerializer(BigDecimal.class));
-                    jacksonObjectMapperBuilder.deserializerByType(BigDecimal.class, new Min2DecimalPlacesBigDecimalDeserializer());
+                    jacksonObjectMapperBuilder.deserializerByType(BigDecimal.class, new BigDecimalDeserializer());
                     jacksonObjectMapperBuilder.serializerByType(DateTime.class, new DateTimeSerializer(DateTime.class));
                     jacksonObjectMapperBuilder.deserializerByType(DateTime.class, new DateTimeDeserializer());
                     jacksonObjectMapperBuilder.serializationInclusion(JsonInclude.Include.ALWAYS);
@@ -77,29 +77,15 @@ public class CustomObjectMapper {
 
         @Override
         public void serialize(BigDecimal bigDecimal, JsonGenerator generator, SerializerProvider provider) throws IOException {
-            generator.writeString(setScale(bigDecimal));
-        }
-
-        private String setScale(BigDecimal bigDecimal) {
-            if (bigDecimal.scale() < 2) {
-                return bigDecimal.setScale(2, RoundingMode.HALF_EVEN).toString();
-            }
-            return bigDecimal.toString();
+            generator.writeString(String.valueOf(bigDecimal));
         }
     }
 
-    public static class Min2DecimalPlacesBigDecimalDeserializer extends NumberDeserializers.BigDecimalDeserializer {
-
+    public static class BigDecimalDeserializer extends NumberDeserializers.BigDecimalDeserializer {
         @Override
         public BigDecimal deserialize(JsonParser parser, DeserializationContext context) throws IOException {
-            return setScale(super.deserialize(parser, context));
+            return super.deserialize(parser, context);
         }
 
-        private BigDecimal setScale(BigDecimal bigDecimal) {
-            if (bigDecimal.scale() < 2) {
-                return bigDecimal.setScale(2, RoundingMode.HALF_EVEN);
-            }
-            return bigDecimal;
-        }
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/CustomObjectMapper.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/CustomObjectMapper.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright © 2020-2021 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.NumberDeserializers;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormatter;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import static org.joda.time.format.ISODateTimeFormat.dateTimeNoMillis;
+
+public class CustomObjectMapper {
+    private static CustomObjectMapper customObjectMapper;
+    private static ObjectMapper objectMapper;
+
+    private CustomObjectMapper() {
+        Jackson2ObjectMapperBuilderCustomizer customizer =
+                jacksonObjectMapperBuilder -> {
+                    jacksonObjectMapperBuilder.featuresToEnable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+                    jacksonObjectMapperBuilder.serializerByType(BigDecimal.class, new BigDecimalSerializer(BigDecimal.class));
+                    jacksonObjectMapperBuilder.deserializerByType(BigDecimal.class, new BigDecimalDeserializer());
+                    jacksonObjectMapperBuilder.serializerByType(DateTime.class, new DateTimeSerializer(DateTime.class));
+                    jacksonObjectMapperBuilder.deserializerByType(DateTime.class, new DateTimeDeserializer());
+                    jacksonObjectMapperBuilder.serializationInclusion(JsonInclude.Include.ALWAYS);
+                };
+
+        Jackson2ObjectMapperBuilder builder = Jackson2ObjectMapperBuilder.json();
+        customizer.customize(builder);
+
+        objectMapper = builder.build();
+        objectMapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+    }
+
+    public static CustomObjectMapper getCustomObjectMapper() {
+        if (customObjectMapper == null) {
+            customObjectMapper = new CustomObjectMapper();
+        }
+
+        return customObjectMapper;
+    }
+
+    public static ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    public static class BigDecimalSerializer extends StdSerializer<BigDecimal> {
+
+        public BigDecimalSerializer(Class<BigDecimal> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(BigDecimal bigDecimal, JsonGenerator generator, SerializerProvider provider) throws IOException {
+            generator.writeString(setScale(bigDecimal));
+        }
+
+        private String setScale(BigDecimal bigDecimal) {
+            if (bigDecimal.scale() > 2) {
+                return bigDecimal.setScale(2, RoundingMode.HALF_EVEN).toString();
+            }
+            return bigDecimal.toString();
+        }
+    }
+
+    public static class BigDecimalDeserializer extends NumberDeserializers.BigDecimalDeserializer {
+
+        @Override
+        public BigDecimal deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            return setScale(super.deserialize(parser, context));
+        }
+
+        private BigDecimal setScale(BigDecimal bigDecimal) {
+            if (bigDecimal.scale() > 2) {
+                return bigDecimal.setScale(2, RoundingMode.HALF_EVEN);
+            }
+            return bigDecimal;
+        }
+    }
+
+    public static class DateTimeSerializer extends StdSerializer<DateTime> {
+
+        public DateTimeSerializer(Class<DateTime> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(DateTime dateTime, JsonGenerator generator, SerializerProvider provider) throws IOException {
+            generator.writeString(dateTime.toDateTimeISO().toString(dateTimeNoMillis()));
+        }
+    }
+
+    public static class DateTimeDeserializer extends StdDeserializer<DateTime> {
+
+        public DateTimeDeserializer() {
+            super(DateTime.class);
+        }
+
+        @Override
+        public DateTime deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            String date = parser.getValueAsString();
+            return DateTime.parse(date, dateTimeNoMillis());
+        }
+
+    }
+}

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/DefaultData.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/DefaultData.java
@@ -15,11 +15,19 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.NumberDeserializers;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational2DataInitiationExchangeRateInformation;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.common.Currencies.fromCode;
 
@@ -30,7 +38,7 @@ public class DefaultData {
     {
         return new OBWriteInternational2DataInitiationExchangeRateInformation()
                 .rateType(OBExchangeRateType2Code.AGREED)
-                .exchangeRate(new BigDecimal(ExchangeRate.getConversionRateForCurrency(fromCode(instructedAmountCurrency), fromCode(currencyOfTransfer))))
+                .exchangeRate(BigDecimal.valueOf(ExchangeRate.getConversionRateForCurrency(fromCode(instructedAmountCurrency), fromCode(currencyOfTransfer))))
                 .contractIdentification(CONTRACT_IDENTIFICATION)
                 .unitCurrency(currencyOfTransfer);
     }
@@ -39,7 +47,7 @@ public class DefaultData {
     {
         return new OBWriteInternational3DataInitiationExchangeRateInformation()
                 .rateType(OBExchangeRateType2Code.AGREED)
-                .exchangeRate(new BigDecimal(ExchangeRate.getConversionRateForCurrency(fromCode(instructedAmountCurrency), fromCode(currencyOfTransfer))))
+                .exchangeRate(BigDecimal.valueOf(ExchangeRate.getConversionRateForCurrency(fromCode(instructedAmountCurrency), fromCode(currencyOfTransfer))))
                 .contractIdentification(CONTRACT_IDENTIFICATION)
                 .unitCurrency(currencyOfTransfer);
     }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/DefaultData.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/utils/DefaultData.java
@@ -15,40 +15,20 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.deser.std.NumberDeserializers;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational2DataInitiationExchangeRateInformation;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-
-import static com.forgerock.securebanking.openbanking.uk.rs.common.Currencies.fromCode;
-
 public class DefaultData {
-    private static final String CONTRACT_IDENTIFICATION = "/tbill/2018/T102993";
-
-    public static OBWriteInternational2DataInitiationExchangeRateInformation defaultOBWriteInternational2DataInitiationExchangeRateInformation(String instructedAmountCurrency, String currencyOfTransfer)
-    {
+    public static OBWriteInternational2DataInitiationExchangeRateInformation defaultOBWriteInternational2DataInitiationExchangeRateInformation(String currencyOfTransfer) {
         return new OBWriteInternational2DataInitiationExchangeRateInformation()
-                .rateType(OBExchangeRateType2Code.AGREED)
-                .exchangeRate(BigDecimal.valueOf(ExchangeRate.getConversionRateForCurrency(fromCode(instructedAmountCurrency), fromCode(currencyOfTransfer))))
-                .contractIdentification(CONTRACT_IDENTIFICATION)
+                .rateType(OBExchangeRateType2Code.ACTUAL)
                 .unitCurrency(currencyOfTransfer);
     }
 
-    public static OBWriteInternational3DataInitiationExchangeRateInformation defaultOBWriteInternational3DataInitiationExchangeRateInformation(String instructedAmountCurrency, String currencyOfTransfer)
-    {
+    public static OBWriteInternational3DataInitiationExchangeRateInformation defaultOBWriteInternational3DataInitiationExchangeRateInformation(String currencyOfTransfer) {
         return new OBWriteInternational3DataInitiationExchangeRateInformation()
-                .rateType(OBExchangeRateType2Code.AGREED)
-                .exchangeRate(BigDecimal.valueOf(ExchangeRate.getConversionRateForCurrency(fromCode(instructedAmountCurrency), fromCode(currencyOfTransfer))))
-                .contractIdentification(CONTRACT_IDENTIFICATION)
+                .rateType(OBExchangeRateType2Code.ACTUAL)
                 .unitCurrency(currencyOfTransfer);
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticScheduledPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticScheduledPaymentConsentValidation.java
@@ -22,7 +22,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent4;
 /**
  * Validation class for Domestic Payment consent request
  * <li>
- *     Domestic Scheduled Payment
+ * Domestic Scheduled Payment
  *     <ul>
  *         <li>From 3.1.2 to 3.1.3 {@link OBWriteDomesticScheduledConsent3}</li>
  *         <li>From 3.1.4 to 3.1.10 {@link OBWriteDomesticScheduledConsent4}</li>

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticStandingOrdersConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticStandingOrdersConsentValidation.java
@@ -21,7 +21,7 @@ import uk.org.openbanking.datamodel.payment.*;
 /**
  * Validation class for Domestic Payment consent request
  * <li>
- *     Domestic Standing Order
+ * Domestic Standing Order
  *     <ul>
  *         <li>For 3.1.2 {@link OBWriteDomesticStandingOrderConsent4}</li>
  *         <li>From 3.1.3 to 3.1.10 {@link OBWriteDomesticStandingOrderConsent5}</li>

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticStandingOrdersConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/DomesticStandingOrdersConsentValidation.java
@@ -21,7 +21,7 @@ import uk.org.openbanking.datamodel.payment.*;
 /**
  * Validation class for Domestic Payment consent request
  * <li>
- *     Domestic Standing order
+ *     Domestic Standing Order
  *     <ul>
  *         <li>For 3.1.2 {@link OBWriteDomesticStandingOrderConsent4}</li>
  *         <li>From 3.1.3 to 3.1.10 {@link OBWriteDomesticStandingOrderConsent5}</li>
@@ -44,25 +44,31 @@ public class DomesticStandingOrdersConsentValidation extends PaymentConsentValid
             validate(((OBWriteDomesticStandingOrderConsent4) consent).getData().getInitiation().getFirstPaymentAmount());
             validate(((OBWriteDomesticStandingOrderConsent4) consent).getData().getInitiation().getRecurringPaymentAmount());
             validate(((OBWriteDomesticStandingOrderConsent4) consent).getData().getInitiation().getFinalPaymentAmount());
-            return;
+        } else if (consent instanceof OBWriteDomesticStandingOrderConsent5) {
+            validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getFirstPaymentAmount());
+            validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getRecurringPaymentAmount());
+            validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getFinalPaymentAmount());
         }
-        validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getFirstPaymentAmount());
-        validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getRecurringPaymentAmount());
-        validate(((OBWriteDomesticStandingOrderConsent5) consent).getData().getInitiation().getFinalPaymentAmount());
     }
 
     private void validate(OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount firstPaymentAmount) {
-        validateAmount(firstPaymentAmount.getAmount());
-        validateCurrency(firstPaymentAmount.getCurrency());
+        if (!isNull(firstPaymentAmount, "FirstPaymentAmount")) {
+            validateAmount(firstPaymentAmount.getAmount());
+            validateCurrency(firstPaymentAmount.getCurrency());
+        }
     }
 
     private void validate(OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount recurringPaymentAmount) {
-        validateAmount(recurringPaymentAmount.getAmount());
-        validateCurrency(recurringPaymentAmount.getCurrency());
+        if (recurringPaymentAmount != null) {
+            validateAmount(recurringPaymentAmount.getAmount());
+            validateCurrency(recurringPaymentAmount.getCurrency());
+        }
     }
 
     private void validate(OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount finalPaymentAmount) {
-        validateAmount(finalPaymentAmount.getAmount());
-        validateCurrency(finalPaymentAmount.getCurrency());
+        if (finalPaymentAmount != null) {
+            validateAmount(finalPaymentAmount.getAmount());
+            validateCurrency(finalPaymentAmount.getCurrency());
+        }
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/FilePaymentConsentValidation.java
@@ -21,7 +21,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
 /**
  * Validation class for Domestic Payment consent request
  * <li>
- *     File Payment
+ * File Payment
  *     <ul>
  *         <li>From 3.1.2 to 3.1.10 {@link OBWriteFileConsent3}</li>
  *     </ul>

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/GenericValidations.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/GenericValidations.java
@@ -179,7 +179,7 @@ public abstract class GenericValidations {
         }
     }
 
-    private boolean isNull(String value, String valueName) {
+    public boolean isNull(String value, String valueName) {
         if (Strings.isNullOrEmpty(value)) {
             errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
                     String.format("'%s' cannot be null to be validate", valueName)
@@ -189,7 +189,7 @@ public abstract class GenericValidations {
         return false;
     }
 
-    private boolean isNull(Object object, String objectName) {
+    public boolean isNull(Object object, String objectName) {
         if (Objects.isNull(object)) {
             errors.add(OBRIErrorType.DATA_INVALID_REQUEST.toOBError1(
                     String.format("'%s' cannot be null to be validate", objectName)

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalPaymentConsentValidation.java
@@ -23,7 +23,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
 /**
  * Validation class for Domestic Payment consent request
  * <li>
- *     International Payment
+ * International Payment
  *     <ul>
  *         <li>For 3.1.2 {@link OBWriteInternationalConsent3}</li>
  *         <li>For 3.1.3 {@link OBWriteInternationalConsent4}</li>

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalScheduledPaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalScheduledPaymentConsentValidation.java
@@ -23,14 +23,13 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent
 /**
  * Validation class for Domestic Payment consent request
  * <li>
- *     International Scheduled Payment
+ * International Scheduled Payment
  *     <ul>
  *         <li>For 3.1.2 {@link OBWriteInternationalScheduledConsent3}</li>
  *         <li>For 3.1.3 {@link OBWriteInternationalScheduledConsent4}</li>
  *         <li>From 3.1.4 to 3.1.10 {@link OBWriteInternationalScheduledConsent5}</li>
  *     </ul>
  * </li>
- *
  */
 public class InternationalScheduledPaymentConsentValidation extends PaymentConsentValidation {
     @Override

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalStandingOrdersConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/InternationalStandingOrdersConsentValidation.java
@@ -23,14 +23,13 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderCon
 /**
  * Validation class for Domestic Payment consent request
  * <li>
- *     International Standing Order
+ * International Standing Order
  *     <ul>
  *         <li>For 3.1.2 {@link OBWriteInternationalStandingOrderConsent4}</li>
  *         <li>For 3.1.3 {@link OBWriteInternationalStandingOrderConsent5}</li>
  *         <li>From 3.1.4 to 3.1.10 {@link OBWriteInternationalStandingOrderConsent6}</li>
  *     </ul>
  * </li>
- *
  */
 public class InternationalStandingOrdersConsentValidation extends PaymentConsentValidation {
     @Override

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidation.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidation.java
@@ -20,16 +20,14 @@ import com.forgerock.securebanking.openbanking.uk.common.api.meta.obie.OBVersion
 public abstract class PaymentConsentValidation extends GenericValidations {
 
     /**
-     *
      * @param version {@link OBVersion} is the api version to identify the request object to be validated
      * @return the request consent class by version
      */
     public abstract Class getRequestClass(OBVersion version);
 
     /**
-     *
      * @param consent the consent request object
-     * @param <T> dealing generic type
+     * @param <T>     dealing generic type
      */
     public abstract <T> void validate(T consent);
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidationFactory.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/validation/PaymentConsentValidationFactory.java
@@ -24,6 +24,7 @@ public class PaymentConsentValidationFactory {
 
     /**
      * Get the validation instance by consent type
+     *
      * @param consentId
      * @return a {@link PaymentConsentValidation} implementation instance
      */

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/RsApplicationConfiguration.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/RsApplicationConfiguration.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils.CustomObjectMapper;
-import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils.DefaultData;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.joda.time.DateTime;
@@ -33,6 +32,8 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+import uk.org.openbanking.jackson.DateTimeSerializer;
+import uk.org.openbanking.jackson.DateTimeDeserializer;
 
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
@@ -78,10 +79,8 @@ public class RsApplicationConfiguration {
             jacksonObjectMapperBuilder.featuresToEnable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL);
             jacksonObjectMapperBuilder.modules(new JodaModule());
             jacksonObjectMapperBuilder.featuresToEnable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
-            jacksonObjectMapperBuilder.serializerByType(BigDecimal.class, new CustomObjectMapper.BigDecimalSerializer(BigDecimal.class));
-            jacksonObjectMapperBuilder.deserializerByType(BigDecimal.class, new CustomObjectMapper.BigDecimalDeserializer());
-            jacksonObjectMapperBuilder.deserializerByType(DateTime.class, new CustomObjectMapper.DateTimeDeserializer());
-            jacksonObjectMapperBuilder.serializerByType(DateTime.class, new CustomObjectMapper.DateTimeSerializer(DateTime.class));
+            jacksonObjectMapperBuilder.deserializerByType(DateTime.class, new DateTimeDeserializer());
+            jacksonObjectMapperBuilder.serializerByType(DateTime.class, new DateTimeSerializer(DateTime.class));
             jacksonObjectMapperBuilder.serializationInclusion(JsonInclude.Include.ALWAYS);
         };
     }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/RsApplicationConfiguration.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/configuration/RsApplicationConfiguration.java
@@ -19,8 +19,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils.CustomObjectMapper;
+import com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.utils.DefaultData;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -31,6 +34,7 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
+import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.TimeZone;
@@ -73,7 +77,12 @@ public class RsApplicationConfiguration {
             jacksonObjectMapperBuilder.featuresToDisable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
             jacksonObjectMapperBuilder.featuresToEnable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL);
             jacksonObjectMapperBuilder.modules(new JodaModule());
-            jacksonObjectMapperBuilder.dateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ"));
+            jacksonObjectMapperBuilder.featuresToEnable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
+            jacksonObjectMapperBuilder.serializerByType(BigDecimal.class, new CustomObjectMapper.BigDecimalSerializer(BigDecimal.class));
+            jacksonObjectMapperBuilder.deserializerByType(BigDecimal.class, new CustomObjectMapper.BigDecimalDeserializer());
+            jacksonObjectMapperBuilder.deserializerByType(DateTime.class, new CustomObjectMapper.DateTimeDeserializer());
+            jacksonObjectMapperBuilder.serializerByType(DateTime.class, new CustomObjectMapper.DateTimeSerializer(DateTime.class));
+            jacksonObjectMapperBuilder.serializationInclusion(JsonInclude.Include.ALWAYS);
         };
     }
 }

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsControllerTest.java
@@ -108,7 +108,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -126,7 +126,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -218,7 +218,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -274,7 +274,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -292,7 +292,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -384,7 +384,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -440,7 +440,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -458,7 +458,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/CalculateResponseElementsControllerTest.java
@@ -34,8 +34,7 @@ import uk.org.openbanking.datamodel.payment.*;
 
 import java.net.URI;
 
-import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.API_VERSION_DESCRIPTION;
-import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.INTENT_TYPE_DESCRIPTION;
+import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.*;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredBackofficeHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -109,7 +108,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -127,7 +126,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -145,7 +144,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -182,7 +181,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -219,7 +218,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -275,7 +274,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -293,7 +292,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -311,7 +310,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -348,7 +347,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -385,7 +384,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -441,7 +440,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -459,7 +458,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 
@@ -477,7 +476,7 @@ public class CalculateResponseElementsControllerTest {
 
         // Then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getData().getInitiation()).isEqualTo(consentRequest.getData().getInitiation());
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(consentRequest.getData().getInitiation()));
         assertThat(response.getBody().getData().getCharges()).isNotEmpty();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiControllerTest.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_0.domesticscheduledpayments;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.DomesticScheduledPaymentSubmissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse1;
 
 import java.util.UUID;
 
+import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.customObjectMapper;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -63,7 +65,7 @@ public class DomesticScheduledPaymentsApiControllerTest {
     }
 
     @Test
-    public void shouldCreateDomesticScheduledPayment() {
+    public void shouldCreateDomesticScheduledPayment() throws JsonProcessingException {
         // Given
         OBWriteDomesticScheduled1 payment = aValidOBWriteDomesticScheduled1();
         HttpEntity<OBWriteDomesticScheduled1> request = new HttpEntity<>(payment, HTTP_HEADERS);
@@ -76,12 +78,12 @@ public class DomesticScheduledPaymentsApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         OBWriteDataDomesticScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
-        assertThat(responseData.getInitiation()).isEqualTo(payment.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(payment.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-scheduled-payments/" + responseData.getDomesticScheduledPaymentId())).isTrue();
     }
 
     @Test
-    public void shouldGetDomesticScheduledPaymentById() {
+    public void shouldGetDomesticScheduledPaymentById() throws JsonProcessingException {
         // Given
         OBWriteDomesticScheduled1 payment = aValidOBWriteDomesticScheduled1();
         HttpEntity<OBWriteDomesticScheduled1> request = new HttpEntity<>(payment, HTTP_HEADERS);
@@ -95,7 +97,7 @@ public class DomesticScheduledPaymentsApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         OBWriteDataDomesticScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
-        assertThat(responseData.getInitiation()).isEqualTo(payment.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(payment.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-scheduled-payments/" + responseData.getDomesticScheduledPaymentId())).isTrue();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiControllerTest.java
@@ -82,7 +82,7 @@ public class DomesticScheduledPaymentsApiControllerTest {
         OBWriteDataDomesticScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
         assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(payment.getData().getInitiation()));
-        assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-scheduled-payments/" + responseData.getDomesticScheduledPaymentId())).isTrue();
+        assertThat(response.getBody().getLinks().getSelf().getPath().endsWith("/domestic-scheduled-payments/" + responseData.getDomesticScheduledPaymentId())).isTrue();
     }
 
     @Test
@@ -101,7 +101,7 @@ public class DomesticScheduledPaymentsApiControllerTest {
         OBWriteDataDomesticScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
         assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(payment.getData().getInitiation()));
-        assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-scheduled-payments/" + responseData.getDomesticScheduledPaymentId())).isTrue();
+        assertThat(response.getBody().getLinks().getSelf().getPath().endsWith("/domestic-scheduled-payments/" + responseData.getDomesticScheduledPaymentId())).isTrue();
     }
 
     private String scheduledPaymentsUrl() {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApiControllerTest.java
@@ -16,6 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_0.domesticscheduledpayments;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.DomesticScheduledPaymentSubmissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,6 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledResponse1;
 
 import java.util.UUID;
 
-import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.customObjectMapper;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -59,6 +59,9 @@ public class DomesticScheduledPaymentsApiControllerTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @AfterEach
     void removeData() {
         scheduledPaymentRepository.deleteAll();
@@ -78,7 +81,7 @@ public class DomesticScheduledPaymentsApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         OBWriteDataDomesticScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(payment.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(payment.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-scheduled-payments/" + responseData.getDomesticScheduledPaymentId())).isTrue();
     }
 
@@ -97,7 +100,7 @@ public class DomesticScheduledPaymentsApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         OBWriteDataDomesticScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(payment.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(payment.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-scheduled-payments/" + responseData.getDomesticScheduledPaymentId())).isTrue();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_0.domesticstandingorders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.DomesticStandingOrderPaymentSubmissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse
 
 import java.util.UUID;
 
+import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.customObjectMapper;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -63,7 +65,7 @@ public class DomesticStandingOrdersApiControllerTest {
     }
 
     @Test
-    public void shouldCreateDomesticStandingOrder() {
+    public void shouldCreateDomesticStandingOrder() throws JsonProcessingException {
         // Given
         OBWriteDomesticStandingOrder1 standingOrder = aValidOBWriteDomesticStandingOrder1();
         HttpEntity<OBWriteDomesticStandingOrder1> request = new HttpEntity<>(standingOrder, HTTP_HEADERS);
@@ -76,12 +78,12 @@ public class DomesticStandingOrdersApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         OBWriteDataDomesticStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
-        assertThat(responseData.getInitiation()).isEqualTo(standingOrder.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(standingOrder.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-standing-orders/" + responseData.getDomesticStandingOrderId())).isTrue();
     }
 
     @Test
-    public void shouldGetDomesticStandingOrderById() {
+    public void shouldGetDomesticStandingOrderById() throws JsonProcessingException {
         // Given
         OBWriteDomesticStandingOrder1 standingOrder = aValidOBWriteDomesticStandingOrder1();
         HttpEntity<OBWriteDomesticStandingOrder1> request = new HttpEntity<>(standingOrder, HTTP_HEADERS);
@@ -95,7 +97,7 @@ public class DomesticStandingOrdersApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         OBWriteDataDomesticStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
-        assertThat(responseData.getInitiation()).isEqualTo(standingOrder.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(standingOrder.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-standing-orders/" + responseData.getDomesticStandingOrderId())).isTrue();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
@@ -82,7 +82,7 @@ public class DomesticStandingOrdersApiControllerTest {
         OBWriteDataDomesticStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
         assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(standingOrder.getData().getInitiation()));
-        assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-standing-orders/" + responseData.getDomesticStandingOrderId())).isTrue();
+        assertThat(response.getBody().getLinks().getSelf().getPath().endsWith("/domestic-standing-orders/" + responseData.getDomesticStandingOrderId())).isTrue();
     }
 
     @Test
@@ -101,7 +101,7 @@ public class DomesticStandingOrdersApiControllerTest {
         OBWriteDataDomesticStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
         assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(standingOrder.getData().getInitiation()));
-        assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-standing-orders/" + responseData.getDomesticStandingOrderId())).isTrue();
+        assertThat(response.getBody().getLinks().getSelf().getPath().endsWith("/domestic-standing-orders/" + responseData.getDomesticStandingOrderId())).isTrue();
     }
 
     private String standingOrderUrl() {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApiControllerTest.java
@@ -16,6 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_0.domesticstandingorders;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.DomesticStandingOrderPaymentSubmissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,6 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderResponse
 
 import java.util.UUID;
 
-import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.customObjectMapper;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -59,6 +59,9 @@ public class DomesticStandingOrdersApiControllerTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @AfterEach
     void removeData() {
         standingOrderRepository.deleteAll();
@@ -78,7 +81,7 @@ public class DomesticStandingOrdersApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         OBWriteDataDomesticStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(standingOrder.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(standingOrder.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-standing-orders/" + responseData.getDomesticStandingOrderId())).isTrue();
     }
 
@@ -97,7 +100,7 @@ public class DomesticStandingOrdersApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         OBWriteDataDomesticStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(standingOrder.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(standingOrder.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/domestic-standing-orders/" + responseData.getDomesticStandingOrderId())).isTrue();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiControllerTest.java
@@ -16,6 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_0.internationalscheduledpayments;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.InternationalScheduledPaymentSubmissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -29,10 +30,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduled1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledResponse1;
-
 import java.util.UUID;
-
-import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.customObjectMapper;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -59,6 +57,9 @@ public class InternationalScheduledPaymentsApiControllerTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @AfterEach
     void removeData() {
         scheduledPaymentRepository.deleteAll();
@@ -78,7 +79,7 @@ public class InternationalScheduledPaymentsApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         OBWriteDataInternationalScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(payment.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(payment.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/international-scheduled-payments/" + responseData.getInternationalScheduledPaymentId())).isTrue();
     }
 
@@ -97,7 +98,7 @@ public class InternationalScheduledPaymentsApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         OBWriteDataInternationalScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(payment.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(payment.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/international-scheduled-payments/" + responseData.getInternationalScheduledPaymentId())).isTrue();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiControllerTest.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_0.internationalscheduledpayments;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.InternationalScheduledPaymentSubmissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledRespons
 
 import java.util.UUID;
 
+import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.customObjectMapper;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -63,7 +65,7 @@ public class InternationalScheduledPaymentsApiControllerTest {
     }
 
     @Test
-    public void shouldCreateInternationalScheduledPayment() {
+    public void shouldCreateInternationalScheduledPayment() throws JsonProcessingException {
         // Given
         OBWriteInternationalScheduled1 payment = aValidOBWriteInternationalScheduled1();
         HttpEntity<OBWriteInternationalScheduled1> request = new HttpEntity<>(payment, HTTP_HEADERS);
@@ -76,12 +78,12 @@ public class InternationalScheduledPaymentsApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         OBWriteDataInternationalScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
-        assertThat(responseData.getInitiation()).isEqualTo(payment.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(payment.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/international-scheduled-payments/" + responseData.getInternationalScheduledPaymentId())).isTrue();
     }
 
     @Test
-    public void shouldGetInternationalScheduledPaymentById() {
+    public void shouldGetInternationalScheduledPaymentById() throws JsonProcessingException {
         // Given
         OBWriteInternationalScheduled1 payment = aValidOBWriteInternationalScheduled1();
         HttpEntity<OBWriteInternationalScheduled1> request = new HttpEntity<>(payment, HTTP_HEADERS);
@@ -95,7 +97,7 @@ public class InternationalScheduledPaymentsApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         OBWriteDataInternationalScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
-        assertThat(responseData.getInitiation()).isEqualTo(payment.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(payment.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/international-scheduled-payments/" + responseData.getInternationalScheduledPaymentId())).isTrue();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApiControllerTest.java
@@ -80,7 +80,7 @@ public class InternationalScheduledPaymentsApiControllerTest {
         OBWriteDataInternationalScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
         assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(payment.getData().getInitiation()));
-        assertThat(response.getBody().getLinks().getSelf().endsWith("/international-scheduled-payments/" + responseData.getInternationalScheduledPaymentId())).isTrue();
+        assertThat(response.getBody().getLinks().getSelf().getPath().endsWith("/international-scheduled-payments/" + responseData.getInternationalScheduledPaymentId())).isTrue();
     }
 
     @Test
@@ -99,7 +99,7 @@ public class InternationalScheduledPaymentsApiControllerTest {
         OBWriteDataInternationalScheduledResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(payment.getData().getConsentId());
         assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(payment.getData().getInitiation()));
-        assertThat(response.getBody().getLinks().getSelf().endsWith("/international-scheduled-payments/" + responseData.getInternationalScheduledPaymentId())).isTrue();
+        assertThat(response.getBody().getLinks().getSelf().getPath().endsWith("/international-scheduled-payments/" + responseData.getInternationalScheduledPaymentId())).isTrue();
     }
 
     private String scheduledPaymentsUrl() {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiControllerTest.java
@@ -80,7 +80,7 @@ public class InternationalStandingOrdersApiControllerTest {
         OBWriteDataInternationalStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
         assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(standingOrder.getData().getInitiation()));
-        assertThat(response.getBody().getLinks().getSelf().endsWith("/international-standing-orders/" + responseData.getInternationalStandingOrderId())).isTrue();
+        assertThat(response.getBody().getLinks().getSelf().getPath().endsWith("/international-standing-orders/" + responseData.getInternationalStandingOrderId())).isTrue();
     }
 
     @Test
@@ -99,7 +99,7 @@ public class InternationalStandingOrdersApiControllerTest {
         OBWriteDataInternationalStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
         assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(standingOrder.getData().getInitiation()));
-        assertThat(response.getBody().getLinks().getSelf().endsWith("/international-standing-orders/" + responseData.getInternationalStandingOrderId())).isTrue();
+        assertThat(response.getBody().getLinks().getSelf().getPath().endsWith("/international-standing-orders/" + responseData.getInternationalStandingOrderId())).isTrue();
     }
 
     private String standingOrderUrl() {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiControllerTest.java
@@ -15,6 +15,7 @@
  */
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_0.internationalstandingorders;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.InternationalStandingOrderPaymentSubmissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderRes
 
 import java.util.UUID;
 
+import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.customObjectMapper;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -63,7 +65,7 @@ public class InternationalStandingOrdersApiControllerTest {
     }
 
     @Test
-    public void shouldCreateInternationalStandingOrder() {
+    public void shouldCreateInternationalStandingOrder() throws JsonProcessingException {
         // Given
         OBWriteInternationalStandingOrder1 standingOrder = aValidOBWriteInternationalStandingOrder1();
         HttpEntity<OBWriteInternationalStandingOrder1> request = new HttpEntity<>(standingOrder, HTTP_HEADERS);
@@ -76,12 +78,12 @@ public class InternationalStandingOrdersApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         OBWriteDataInternationalStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
-        assertThat(responseData.getInitiation()).isEqualTo(standingOrder.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(standingOrder.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/international-standing-orders/" + responseData.getInternationalStandingOrderId())).isTrue();
     }
 
     @Test
-    public void shouldGetInternationalStandingOrderById() {
+    public void shouldGetInternationalStandingOrderById() throws JsonProcessingException {
         // Given
         OBWriteInternationalStandingOrder1 standingOrder = aValidOBWriteInternationalStandingOrder1();
         HttpEntity<OBWriteInternationalStandingOrder1> request = new HttpEntity<>(standingOrder, HTTP_HEADERS);
@@ -95,7 +97,7 @@ public class InternationalStandingOrdersApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         OBWriteDataInternationalStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
-        assertThat(responseData.getInitiation()).isEqualTo(standingOrder.getData().getInitiation());
+        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(standingOrder.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/international-standing-orders/" + responseData.getInternationalStandingOrderId())).isTrue();
     }
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApiControllerTest.java
@@ -16,6 +16,7 @@
 package com.forgerock.securebanking.openbanking.uk.rs.api.obie.payment.v3_0.internationalstandingorders;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.payments.InternationalStandingOrderPaymentSubmissionRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -29,10 +30,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrde
 import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderResponse1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder1;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderResponse1;
-
 import java.util.UUID;
-
-import static com.forgerock.securebanking.openbanking.uk.rs.api.backoffice.payment.CalculateResponseElementsController.customObjectMapper;
 import static com.forgerock.securebanking.openbanking.uk.rs.testsupport.api.HttpHeadersTestDataFactory.requiredPaymentHttpHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -59,6 +57,9 @@ public class InternationalStandingOrdersApiControllerTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private ObjectMapper mapper;
+
     @AfterEach
     void removeData() {
         standingOrderRepository.deleteAll();
@@ -78,7 +79,7 @@ public class InternationalStandingOrdersApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         OBWriteDataInternationalStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(standingOrder.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(standingOrder.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/international-standing-orders/" + responseData.getInternationalStandingOrderId())).isTrue();
     }
 
@@ -97,7 +98,7 @@ public class InternationalStandingOrdersApiControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         OBWriteDataInternationalStandingOrderResponse1 responseData = response.getBody().getData();
         assertThat(responseData.getConsentId()).isEqualTo(standingOrder.getData().getConsentId());
-        assertThat(customObjectMapper.getObjectMapper().writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(customObjectMapper.getObjectMapper().writeValueAsString(standingOrder.getData().getInitiation()));
+        assertThat(mapper.writeValueAsString(response.getBody().getData().getInitiation())).isEqualTo(mapper.writeValueAsString(standingOrder.getData().getInitiation()));
         assertThat(response.getBody().getLinks().getSelf().endsWith("/international-standing-orders/" + responseData.getInternationalStandingOrderId())).isTrue();
     }
 


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/442

All the errors are using the following Error model:
```json
{
  "Code": "string",
  "Errors": [
    {
      "ErrorCode": "string",
      "Message": "string",
      "Path": "string"
    }
  ]
}
```

In the RS project for calculate elements APIs we have two types of verification on the request body.
1. The verification of all the required fields and their format/value (the Instructed Amount) for the all the types of Domestic Payments. Returning a DATA_INVALID_REQUEST error type with a custom message if the criteria aren't met.
2. The verification of all the required fields and their format/value (the Instructed Amount, the Exchange Rate Information) for the all the types of International Payments, depending of the rate type (Actual, Indicative, Agreed). Returning a DATA_INVALID_REQUEST error type with a custom message if the criteria aren't met.

