### PR TITLE
450: Preventing the codegen from using JsonNullable

### DIFF
--- a/securebanking-openbanking-uk-rs-obie-api/pom.xml
+++ b/securebanking-openbanking-uk-rs-obie-api/pom.xml
@@ -108,6 +108,7 @@
                                     <generateModels>false</generateModels>
                                     <configOptions>
                                         <dateLibrary>joda</dateLibrary>
+                                        <openApiNullable>false</openApiNullable>
                                     </configOptions>
                                     <addCompileSourceRoot>false</addCompileSourceRoot>
                                 </configuration>


### PR DESCRIPTION
Currently, the codegen produces output which includes an unused import for JsonNullable. This causes issues as this class is not on the classpath and therefore causes compilation errors.

Disabling support for JsonNullable as we don't use this functionality and it seems unlikely that we would want to in the future.

This change has been applied to the common module which contains the datamodel, the change to this project will produce the APIs which will be compatible. See: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk/pull/47

Issue: SecureBankingAccessToolkit/SecureBankingAccessToolkit#450