### PR TITLE
451: Removing timestamp from generated code annotation

### DIFF
--- a/securebanking-openbanking-uk-rs-obie-api/pom.xml
+++ b/securebanking-openbanking-uk-rs-obie-api/pom.xml
@@ -109,6 +109,7 @@
                                     <configOptions>
                                         <dateLibrary>joda</dateLibrary>
                                         <openApiNullable>false</openApiNullable>
+                                        <hideGenerationTimestamp>true</hideGenerationTimestamp>
                                     </configOptions>
                                     <addCompileSourceRoot>false</addCompileSourceRoot>
                                 </configuration>

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/accounts/AccountsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/accounts/AccountsApi.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/aisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/beneficiaries/BeneficiariesApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/beneficiaries/BeneficiariesApi.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-16T08:37:28.078Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/aisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/offers/OffersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/offers/OffersApi.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/aisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/party/PartyApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/party/PartyApi.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/aisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/statements/StatementsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_0/statements/StatementsApi.java
@@ -38,7 +38,7 @@ import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstant
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.ParametersFieldName.FROM_STATEMENT_DATE_TIME;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.ParametersFieldName.TO_STATEMENT_DATE_TIME;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.ACCOUNTS_AND_TRANSACTION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/aisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticpayments/DomesticPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticpayments/DomesticPaymentsApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/file/FilePaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/file/FilePaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalpayments/InternationalPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalpayments/InternationalPaymentsApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_0/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.0", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.0/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticpayments/DomesticPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticpayments/DomesticPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/file/FilePaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/file/FilePaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalpayments/InternationalPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalpayments/InternationalPaymentsApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_1/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -37,7 +37,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-10-10T14:05:22.993+01:00")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.1", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.1/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticpayments/DomesticPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticpayments/DomesticPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.3", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.3/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.3", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.3/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.3", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.3/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/file/FilePaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/file/FilePaymentsApi.java
@@ -40,7 +40,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.3", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.3/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalpayments/InternationalPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalpayments/InternationalPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.3", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.3/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.3", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.3/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_3/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.3", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.3/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticpayments/DomesticPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticpayments/DomesticPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2020-12-19T16:47:08.987291Z[Europe/London]")
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen")
 @Api(tags = {"v3.1.4", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.4/pisp")
 public interface DomesticPaymentsApi {

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -33,7 +33,7 @@ import uk.org.openbanking.datamodel.payment.OBWritePaymentDetailsResponse1;
 import javax.servlet.http.HttpServletRequest;
 import java.security.Principal;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2020-12-19T16:47:08.987291Z[Europe/London]")
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen")
 @Api(tags = {"v3.1.4", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.4/pisp")
 public interface DomesticScheduledPaymentsApi {

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -58,7 +58,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2020-12-19T16:47:08.987291Z[Europe/London]")
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen")
 @Api(tags = {"v3.1.4", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.4/pisp")
 public interface DomesticStandingOrdersApi {

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalpayments/InternationalPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalpayments/InternationalPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2020-12-19T16:47:08.987291Z[Europe/London]")
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen")
 @Api(tags = {"v3.1.4", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.4/pisp")
 public interface InternationalPaymentsApi {

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2020-12-19T16:47:08.987291Z[Europe/London]")
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen")
 @Api(tags = {"v3.1.4", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.4/pisp")
 public interface InternationalScheduledPaymentsApi {

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen", date = "2020-12-19T16:47:08.987291Z[Europe/London]")
+@javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.SpringCodegen")
 @Api(tags = {"v3.1.4", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.4/pisp")
 public interface InternationalStandingOrdersApi {

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.5", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.5/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.5", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.5/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.5", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.5/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/file/FilePaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/file/FilePaymentsApi.java
@@ -40,7 +40,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.5", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.5/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalpayments/InternationalPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.5", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.5/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.5", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.5/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -38,7 +38,7 @@ import java.security.Principal;
 
 import static com.forgerock.securebanking.openbanking.uk.rs.api.obie.ApiConstants.HTTP_DATE_FORMAT;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.5", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.5/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/domesticpayments/DomesticPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/domesticpayments/DomesticPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.6", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.6/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.6", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.6/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -44,7 +44,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.6", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.6/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/file/FilePaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/file/FilePaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.6", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.6/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/internationalpayments/InternationalPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/internationalpayments/InternationalPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.6", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.6/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.6", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.6/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_6/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.6", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.6/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/domesticpayments/DomesticPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/domesticpayments/DomesticPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.7", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.7/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.7", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.7/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -44,7 +44,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.7", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.7/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/file/FilePaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/file/FilePaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.7", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.7/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/internationalpayments/InternationalPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/internationalpayments/InternationalPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.7", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.7/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.7", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.7/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_7/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.7", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.7/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/domesticpayments/DomesticPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/domesticpayments/DomesticPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.8", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.8/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/domesticscheduledpayments/DomesticScheduledPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.8", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.8/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/domesticstandingorders/DomesticStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/domesticstandingorders/DomesticStandingOrdersApi.java
@@ -44,7 +44,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.8", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.8/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/file/FilePaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/file/FilePaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.8", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.8/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/internationalpayments/InternationalPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/internationalpayments/InternationalPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.8", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.8/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/internationalscheduledpayments/InternationalScheduledPaymentsApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.8", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.8/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/internationalstandingorders/InternationalStandingOrdersApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/internationalstandingorders/InternationalStandingOrdersApi.java
@@ -24,7 +24,7 @@ import com.forgerock.securebanking.openbanking.uk.rs.api.swagger.SwaggerApiTags;
 import io.swagger.annotations.Api;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2020-05-22T14:20:48.770Z")
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen")
 
 @Api(tags = {"v3.1.8", SwaggerApiTags.PAYMENT_INITIATION_TAG})
 @RequestMapping(value = "/open-banking/v3.1.8/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/vrp/DomesticVrpsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/vrp/DomesticVrpsApi.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-11-17T13:54:56.728Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
 @Api(tags = {"v3.1.8", SwaggerApiTags.VRP_PAYMENT_TAG})
 @RequestMapping(value = "/open-banking/v3.1.8/pisp")

--- a/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_9/vrp/DomesticVrpsApi.java
+++ b/securebanking-openbanking-uk-rs-obie-api/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_9/vrp/DomesticVrpsApi.java
@@ -35,7 +35,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.security.Principal;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-11-17T13:54:56.728Z[Europe/London]")
+@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen")
 @Validated
 @Api(tags = {"v3.1.8", SwaggerApiTags.VRP_PAYMENT_TAG})
 @RequestMapping(value = "/open-banking/v3.1.9/pisp")

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_1/statements/StatementsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/account/v3_1/statements/StatementsApiController.java
@@ -20,8 +20,6 @@ import com.forgerock.securebanking.openbanking.uk.rs.persistence.repository.acco
 import com.forgerock.securebanking.openbanking.uk.rs.service.statement.StatementPDFService;
 import org.springframework.stereotype.Controller;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2018-06-25T23:06:46.214+01:00")
-
 @Controller("StatementsApiV3.1")
 public class StatementsApiController extends com.forgerock.securebanking.openbanking.uk.rs.api.obie.account.v3_0.statements.StatementsApiController implements StatementsApi {
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/vrp/DomesticVrpsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_8/vrp/DomesticVrpsApiController.java
@@ -48,7 +48,6 @@ import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRRead
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frDomesticVrpResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticVrpPaymentLink;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-11-17T13:54:56.728Z[Europe/London]")
 @Controller("DomesticVrpsApiV3.1.8")
 @Slf4j
 public class DomesticVrpsApiController implements DomesticVrpsApi {

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_9/vrp/DomesticVrpsApiController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_9/vrp/DomesticVrpsApiController.java
@@ -48,7 +48,6 @@ import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRRead
 import static com.forgerock.securebanking.openbanking.uk.rs.common.refund.FRResponseDataRefundFactory.frDomesticVrpResponseDataRefund;
 import static com.forgerock.securebanking.openbanking.uk.rs.common.util.link.LinksHelper.createDomesticVrpPaymentLink;
 
-@javax.annotation.Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2021-11-17T13:54:56.728Z[Europe/London]")
 @Controller("DomesticVrpsApiV3.1.9")
 @Slf4j
 public class DomesticVrpsApiController implements DomesticVrpsApi {


### PR DESCRIPTION
Configuring the codegen hideGenerationTimestamp=true & removing existing timestamps.

Removing Generated annotation from DomesticVrpsApiController & StatementsApiController as these were tagged by mistake.

The aim of this is to remove noise when diffing code which has been regenerated, as the previous impl means there will always be at least 1 differences in every file which gets regenerated.

The same change has already been applied to the datamodel generator settings: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk/pull/52

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/451