### PR TITLE
522: Updating RS consent API to work with the new IDM consent structure

### DIFF
--- a/securebanking-forgerock-rs-platform-client/src/main/java/com/forgerock/securebanking/rs/platform/client/services/CloudPlatformClientService.java
+++ b/securebanking-forgerock-rs-platform-client/src/main/java/com/forgerock/securebanking/rs/platform/client/services/CloudPlatformClientService.java
@@ -42,6 +42,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 @ComponentScan(basePackages = {"com.forgerock.securebanking.rs.platform.client.configuration"})
 class CloudPlatformClientService implements PlatformClient {
 
+    public static final String IDM_RESPOND_OB_INTENT_OBJECT_FIELD = "OBIntentObject";
     private final RestTemplate restTemplate;
     private final ConfigurationPropertiesClient configurationProperties;
 
@@ -73,7 +74,10 @@ class CloudPlatformClientService implements PlatformClient {
             throw new ExceptionClient(clientRequest, ErrorType.INVALID_REQUEST, errorMessage);
         }
 
-        return consentDetails;
+        if (!consentDetails.has(IDM_RESPOND_OB_INTENT_OBJECT_FIELD)) {
+            throw new ExceptionClient(clientRequest, ErrorType.NOT_FOUND, "Server responded with invalid consent response, missing OBIntentObject field");
+        }
+        return consentDetails.getAsJsonObject(IDM_RESPOND_OB_INTENT_OBJECT_FIELD);
     }
 
     private JsonObject request(String intentId, HttpMethod httpMethod) throws ExceptionClient {

--- a/securebanking-forgerock-rs-platform-client/src/main/java/com/forgerock/securebanking/rs/platform/client/services/CloudPlatformClientService.java
+++ b/securebanking-forgerock-rs-platform-client/src/main/java/com/forgerock/securebanking/rs/platform/client/services/CloudPlatformClientService.java
@@ -42,7 +42,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 @ComponentScan(basePackages = {"com.forgerock.securebanking.rs.platform.client.configuration"})
 class CloudPlatformClientService implements PlatformClient {
 
-    public static final String IDM_RESPOND_OB_INTENT_OBJECT_FIELD = "OBIntentObject";
+    private static final String IDM_RESPOND_OB_INTENT_OBJECT_FIELD = "OBIntentObject";
     private final RestTemplate restTemplate;
     private final ConfigurationPropertiesClient configurationProperties;
 

--- a/securebanking-forgerock-rs-platform-client/src/test/java/com/forgerock/securebanking/rs/platform/client/services/PlatformClientServiceTest.java
+++ b/securebanking-forgerock-rs-platform-client/src/test/java/com/forgerock/securebanking/rs/platform/client/services/PlatformClientServiceTest.java
@@ -99,7 +99,7 @@ public class PlatformClientServiceTest {
 
         // Then
         assertThat(idmIntent).isNotNull();
-        assertThat(idmIntent).isEqualTo(intentResponse);
+        assertThat(idmIntent).isEqualTo(intentResponse.getAsJsonObject("OBIntentObject"));
     }
 
     @Test

--- a/securebanking-forgerock-rs-platform-client/src/test/java/com/forgerock/securebanking/rs/platform/client/test/support/DomesticPaymentConsentDetailsTestFactory.java
+++ b/securebanking-forgerock-rs-platform-client/src/test/java/com/forgerock/securebanking/rs/platform/client/test/support/DomesticPaymentConsentDetailsTestFactory.java
@@ -64,7 +64,9 @@ public class DomesticPaymentConsentDetailsTestFactory {
     public static JsonObject aValidDomesticPaymentConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", consentId);
-        consent.add("data", aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntentObject = new JsonObject();
+        obIntentObject.add("Data",  aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntentObject);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -76,7 +78,9 @@ public class DomesticPaymentConsentDetailsTestFactory {
     public static JsonObject aValidOBDomesticPaymentConsentDetailsBuilder(String consentId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", consentId);
-        consent.add("Data", aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntentObject = new JsonObject();
+        obIntentObject.add("Data",  aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntentObject);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", randomUUID().toString());
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -88,7 +92,9 @@ public class DomesticPaymentConsentDetailsTestFactory {
     public static JsonObject aValidDomesticPaymentConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", consentId);
-        consent.add("Data", aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntentObject = new JsonObject();
+        obIntentObject.add("Data",  aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntentObject);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "PISP Name");
@@ -99,7 +105,9 @@ public class DomesticPaymentConsentDetailsTestFactory {
     public static JsonObject aValidOBDomesticPaymentConsentDetailsBuilder(String consentId, String clientId) {
         JsonObject consent = new JsonObject();
         consent.addProperty("id", consentId);
-        consent.add("Data", aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        final JsonObject obIntentObject = new JsonObject();
+        obIntentObject.add("Data",  aValidDomesticPaymentConsentDataDetailsBuilder(consentId));
+        consent.add("OBIntentObject", obIntentObject);
         consent.add("resourceOwnerUsername", null);
         consent.addProperty("oauth2ClientId", clientId);
         consent.addProperty("oauth2ClientName", "PISP Name");

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/ControllerEndpointBlacklistHandlerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/discovery/ControllerEndpointBlacklistHandlerTest.java
@@ -84,14 +84,18 @@ public class ControllerEndpointBlacklistHandlerTest {
         domesticPaymentSubmissionRepository.deleteAll();
     }
 
+    private JsonObject getIntentResponse(OBWriteDomestic2 payment) {
+        return DomesticPaymentConsentDetailsTestFactory.aValidOBDomesticPaymentConsentDetails(
+                payment.getData().getConsentId(),
+                UUID.randomUUID().toString()
+        ).getAsJsonObject("OBIntentObject");
+    }
+
     @Test
     public void shouldCreateDomesticPaymentGivenApiVersionIsEnabled() throws ExceptionClient {
         // Given
         OBWriteDomestic2 payment = aValidOBWriteDomestic2();
-        JsonObject intentResponse = DomesticPaymentConsentDetailsTestFactory.aValidOBDomesticPaymentConsentDetails(
-                payment.getData().getConsentId(),
-                UUID.randomUUID().toString()
-        );
+        JsonObject intentResponse = getIntentResponse(payment);
         given(platformClientService.getIntent(anyString(), anyString())).willReturn(intentResponse);
         HttpEntity<OBWriteDomestic2> request = new HttpEntity<>(payment, PAYMENT_HEADERS);
         String url = paymentsUrl(ENABLED_VERSION);
@@ -121,10 +125,7 @@ public class ControllerEndpointBlacklistHandlerTest {
     public void shouldFailToGetDomesticPaymentGivenApiEndpointIsDisabled() throws ExceptionClient {
         // Given
         OBWriteDomestic2 payment = aValidOBWriteDomestic2();
-        JsonObject intentResponse = DomesticPaymentConsentDetailsTestFactory.aValidOBDomesticPaymentConsentDetails(
-                payment.getData().getConsentId(),
-                UUID.randomUUID().toString()
-        );
+        JsonObject intentResponse = getIntentResponse(payment);
         given(platformClientService.getIntent(anyString(), anyString())).willReturn(intentResponse);
         HttpEntity<OBWriteDomestic2> request = new HttpEntity<>(payment, PAYMENT_HEADERS);
         ResponseEntity<OBWriteDomesticResponse5> persistedPayment = restTemplate.postForEntity(

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticpayments/DomesticPaymentsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_4/domesticpayments/DomesticPaymentsApiControllerTest.java
@@ -79,7 +79,7 @@ public class DomesticPaymentsApiControllerTest {
         JsonObject intentResponse = DomesticPaymentConsentDetailsTestFactory.aValidOBDomesticPaymentConsentDetails(
                 IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId(),
                 UUID.randomUUID().toString()
-        );
+        ).getAsJsonObject("OBIntentObject");
         HttpEntity<OBWriteDomestic2> request = new HttpEntity<>(payment, HTTP_HEADERS);
         given(platformClientService.getIntent(anyString(), anyString())).willReturn(intentResponse);
 

--- a/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApiControllerTest.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/test/java/com/forgerock/securebanking/openbanking/uk/rs/api/obie/payment/v3_1_5/domesticpayments/DomesticPaymentsApiControllerTest.java
@@ -79,7 +79,7 @@ public class DomesticPaymentsApiControllerTest {
         JsonObject intentResponse = DomesticPaymentConsentDetailsTestFactory.aValidOBDomesticPaymentConsentDetails(
                 IntentType.PAYMENT_DOMESTIC_CONSENT.generateIntentId(),
                 UUID.randomUUID().toString()
-        );
+        ).getAsJsonObject("OBIntentObject");
         HttpEntity<OBWriteDomestic2> request = new HttpEntity<>(payment, HTTP_HEADERS);
         given(platformClientService.getIntent(anyString(), anyString())).willReturn(intentResponse);
 


### PR DESCRIPTION
- Consent API expects OBIntentObject field in response object from IDM (via IG)

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/522