### PR TITLE
573: calculate file payment elements fix consent status

### DIFF
--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/domesticpayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/domesticpayments/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse4;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse4Data.StatusEnum.AWAITINGAUTHORISATION;
+
 
 @RestController("CalculateDomesticPaymentsResponseElements_v3.1.4")
 @Slf4j
@@ -45,7 +47,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteDomesticConsentResponse4 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/domesticscheduledpayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/domesticscheduledpayments/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentRespo
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse4Data.StatusEnum.AWAITINGAUTHORISATION;
+
 
 @RestController("CalculateDomesticScheduledPaymentsResponseElements_v3.1.4")
 @Slf4j
@@ -46,7 +48,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteDomesticScheduledConsentResponse4 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/domesticstandingorders/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/domesticstandingorders/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentR
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse5Data.StatusEnum.AWAITINGAUTHORISATION;
+
 
 @RestController("CalculateDomesticStandingOrderResponseElements_v3.1.4")
 @Slf4j
@@ -46,7 +48,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteDomesticStandingOrderConsentResponse5 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/filepayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/filepayments/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse3;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse3Data.StatusEnum.AWAITINGUPLOAD;
+
 
 @RestController("CalculateFilePaymentsResponseElements_v3.1.4")
 @Slf4j
@@ -45,7 +47,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteFileConsentResponse3 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGUPLOAD);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/internationalpayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/internationalpayments/CalculateResponseElementsController.java
@@ -27,8 +27,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent5;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse5Data;
 
 import javax.servlet.http.HttpServletRequest;
+
+import static uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse5Data.StatusEnum.AWAITINGAUTHORISATION;
 
 
 @RestController("CalculateInternationalPaymentsResponseElements_v3.1.4")
@@ -46,7 +49,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteInternationalConsentResponse5 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/internationalscheduledpayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/internationalscheduledpayments/CalculateResponseElementsController.java
@@ -27,8 +27,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent5;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse5Data;
 
 import javax.servlet.http.HttpServletRequest;
+
+import static uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse5Data.StatusEnum.AWAITINGAUTHORISATION;
 
 
 @RestController("CalculateInternationalScheduledPaymentsResponseElements_v3.1.4")
@@ -46,7 +49,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteInternationalScheduledConsentResponse5 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/internationalstandingorders/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_4/internationalstandingorders/CalculateResponseElementsController.java
@@ -27,8 +27,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent6;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse6;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse6Data;
 
 import javax.servlet.http.HttpServletRequest;
+
+import static uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse6Data.StatusEnum.AWAITINGAUTHORISATION;
 
 
 @RestController("CalculateInternationalStandingOrdersResponseElements_v3.1.4")
@@ -46,7 +49,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteInternationalStandingOrderConsentResponse6 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/domesticpayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/domesticpayments/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteDomesticConsentResponse5Data.StatusEnum.AWAITINGAUTHORISATION;
+
 @RestController("CalculateDomesticPaymentsResponseElements_v3.1.5")
 @Slf4j
 public class CalculateResponseElementsController implements CalculateResponseElements {
@@ -45,7 +47,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteDomesticConsentResponse5 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/domesticscheduledpayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/domesticscheduledpayments/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentRespo
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsentResponse5Data.StatusEnum.AWAITINGAUTHORISATION;
+
 @RestController("CalculateDomesticScheduledPaymentsResponseElements_v3.1.5")
 @Slf4j
 public class CalculateResponseElementsController implements CalculateResponseElements {
@@ -45,7 +47,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteDomesticScheduledConsentResponse5 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/domesticstandingorders/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/domesticstandingorders/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentR
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsentResponse6Data.StatusEnum.AWAITINGAUTHORISATION;
+
 
 @RestController("CalculateDomesticStandingOrderResponseElements_v3.1.5")
 @Slf4j
@@ -46,7 +48,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteDomesticStandingOrderConsentResponse6 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/filepayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/filepayments/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteFileConsentResponse4Data.StatusEnum.AWAITINGUPLOAD;
+
 
 @RestController("CalculateFilePaymentsResponseElements_v3.1.5")
 @Slf4j
@@ -45,7 +47,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteFileConsentResponse4 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGUPLOAD);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/internationalpayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/internationalpayments/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse6Data.StatusEnum.AWAITINGAUTHORISATION;
+
 
 @RestController("CalculateInternationalPaymentsResponseElements_v3.1.5")
 @Slf4j
@@ -46,7 +48,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteInternationalConsentResponse6 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/internationalscheduledpayments/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/internationalscheduledpayments/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsentResponse6Data.StatusEnum.AWAITINGAUTHORISATION;
+
 
 @RestController("CalculateInternationalScheduledPaymentsResponseElements_v3.1.5")
 @Slf4j
@@ -46,7 +48,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteInternationalScheduledConsentResponse6 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);

--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/internationalstandingorders/CalculateResponseElementsController.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/api/backoffice/payment/v3_1_5/internationalstandingorders/CalculateResponseElementsController.java
@@ -30,6 +30,8 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderCon
 
 import javax.servlet.http.HttpServletRequest;
 
+import static uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsentResponse7Data.StatusEnum.AWAITINGAUTHORISATION;
+
 
 @RestController("CalculateInternationalStandingOrdersResponseElements_v3.1.5")
 @Slf4j
@@ -46,7 +48,11 @@ public class CalculateResponseElementsController implements CalculateResponseEle
             String xFapiInteractionId,
             HttpServletRequest request) throws OBErrorResponseException {
         try {
-            return ResponseEntity.status(HttpStatus.OK).body(PaymentConsentGeneral.calculate(body, intent, xFapiFinancialId, request));
+            OBWriteInternationalStandingOrderConsentResponse7 response = PaymentConsentGeneral.calculate(
+                    body, intent, xFapiFinancialId, request
+            );
+            response.getData().setStatus(AWAITINGAUTHORISATION);
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         } catch (UnsupportedOperationException | JsonProcessingException e) {
             String message = String.format("%s", e.getMessage());
             log.error(message);


### PR DESCRIPTION
- Set the status in OB response object for all payment consents instead to set the hardcoded status in IG
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/573
Comment: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/573#issuecomment-1277623393