### PR TITLE
Fixing bug with missing links in discovery for international standing…

### DIFF
--- a/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/OBApiReference.java
+++ b/securebanking-openbanking-uk-rs-simulator-server/src/main/java/com/forgerock/securebanking/openbanking/uk/rs/common/OBApiReference.java
@@ -102,8 +102,8 @@ public enum OBApiReference {
     GET_INTERNATIONAL_SCHEDULED_PAYMENT_PAYMENT_ID_PAYMENT_DETAILS(PISP, "GetInternationalScheduledPaymentPaymentIdPaymentDetails", GET, "/pisp/international-scheduled-payments/{InternationalScheduledPaymentId}/payment-details"),
 
     CREATE_INTERNATIONAL_STANDING_ORDER(PISP, "CreateInternationalStandingOrder", POST, "/pisp/international-standing-orders"),
-    GET_INTERNATIONAL_STANDING_ORDER(PISP, "GetInternationalStandingOrder", GET, "/pisp/international-standing-orders/{InternationalStandingOrderId}"),
-    GET_INTERNATIONAL_STANDING_ORDER_ID_PAYMENT_DETAILS(PISP, "GetInternationalStandingOrderInternationalStandingOrderIdPaymentDetails", GET, "/pisp/international-standing-orders/{InternationalStandingOrderId}/payment-details"),
+    GET_INTERNATIONAL_STANDING_ORDER(PISP, "GetInternationalStandingOrder", GET, "/pisp/international-standing-orders/{InternationalStandingOrderPaymentId}"),
+    GET_INTERNATIONAL_STANDING_ORDER_ID_PAYMENT_DETAILS(PISP, "GetInternationalStandingOrderInternationalStandingOrderIdPaymentDetails", GET, "/pisp/international-standing-orders/{InternationalStandingOrderPaymentId}/payment-details"),
 
     CREATE_FILE_PAYMENT_FILE(PISP, "CreateFilePaymentFile", POST, "/pisp/file-payment-consents/{ConsentId}/file"),
     GET_FILE_PAYMENT_FILE(PISP, "GetFilePaymentFile", GET, "/pisp/file-payment-consents/{ConsentId}/file"),


### PR DESCRIPTION
Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/594

Corrected GET_INTERNATIONAL_STANDING_ORDER and GET_INTERNATIONAL_STANDING_ORDER_ID_PAYMENT_DETAILS keys to map the URL's correctly in the discovery controller.